### PR TITLE
replace cforMacro with inline method

### DIFF
--- a/macros/src/main/scala/spire/syntax/macros/cforMacros.scala
+++ b/macros/src/main/scala/spire/syntax/macros/cforMacros.scala
@@ -9,12 +9,11 @@ import tasty.Reflection
 
 import collection.immutable.NumericRange
 
-def cforMacro[A](init: Expr[A], test: Expr[A => Boolean], next: Expr[A => A], body: Expr[A => Unit])
-    given Type[A]: Expr[Unit] = '{
-  var index = $init
-  while (${ test('index) }) {
-    ${ body('index) }
-    index = ${ next('index) }
+inline def cforInline[A](init: => A, test: => A => Boolean, next: => A => A, body: => A => Unit): Unit = {
+  var index = init
+  while (test(index)) {
+    body(index)
+    index = next(index)
   }
 }
 

--- a/src/main/scala/spire/syntax/Syntax.scala
+++ b/src/main/scala/spire/syntax/Syntax.scala
@@ -56,7 +56,7 @@ trait CforSyntax {
   import collection.immutable.NumericRange
 
   inline def cfor[A](init: A)(test: => A => Boolean, next: => A => A)(body: => A => Unit): Unit =
-    ${ cforMacro('init, 'test, 'next, 'body) }
+    cforInline(init, test, next, body)
 
   inline def cforRange(r: => Range)(body: => Int => Unit): Unit =
     ${ cforRangeMacro('r, 'body) }


### PR DESCRIPTION
bodies of by name anonymous functions will be inlined if semantics are preserved