### PR TITLE
generic cforRange macro

### DIFF
--- a/src/main/scala/spire/syntax/Syntax.scala
+++ b/src/main/scala/spire/syntax/Syntax.scala
@@ -58,17 +58,11 @@ trait CforSyntax {
   inline def cfor[A](init: => A)(test: => A => Boolean, next: => A => A)(body: => A => Unit): Unit =
     cforInline(init, test, next, body)
 
-  inline def cforRange(r: => Range)(body: => Int => Unit): Unit =
-    ${ cforRangeMacro('r, 'body) }
+  inline def cforRange[A <: RangeLike](r: => A)(body: => RangeElem[A] => Unit): Unit =
+    ${ cforRangeMacroGen('r, 'body) }
 
-  inline def cforRange2(r1: => Range, r2: => Range)(body: => (Int, Int) => Unit): Unit =
+  inline def cforRange2[A <: RangeLike](r1: => A, r2: => A)(body: => (RangeElem[A], RangeElem[A]) => Unit): Unit =
     cforRange(r1) { x => cforRange(r2) { y => body(x, y) } }
-
-  inline def cforRangeL(r: => NumericRange[Long])(body: => Long => Unit): Unit =
-    ${ cforRangeMacroLong('r, 'body) }
-
-  inline def cforRangeL2(r1: => NumericRange[Long], r2: => NumericRange[Long])(body: => (Long, Long) => Unit): Unit =
-    cforRangeL(r1) { x => cforRangeL(r2) { y => body(x, y) } }
 }
 
 trait AllSyntax extends

--- a/src/test/scala/spire/CforSpec.scala
+++ b/src/test/scala/spire/CforSpec.scala
@@ -38,10 +38,10 @@ object CforSpec extends Properties("cfor") {
     List.range(0, n + 1) =? fill(n)
   }
 
-  property("fillList with cforRangeL using to") = forAll(posNum[Long]) { n =>
+  property("fillList with cforRange[Long] using to") = forAll(posNum[Long]) { n =>
 
     def fill(n: Long): List[Long] = fillList { b =>
-      cforRangeL(0L to n)(b += _)
+      cforRange(0L to n)(b += _)
     }
 
     List.range(0L, n + 1L) =? fill(n)
@@ -56,10 +56,10 @@ object CforSpec extends Properties("cfor") {
     List.range(0, n + 1, step) =? fill(n, step)
   }
 
-  property("fillList with cforRangeL using to, by (positive)") = forAll(posNum[Long], rangeL) { (n, step) =>
+  property("fillList with cforRange[Long] using to, by (positive)") = forAll(posNum[Long], rangeL) { (n, step) =>
 
     def fill(n: Long, step: Long): List[Long] = fillList { b =>
-      cforRangeL(0L to n by step)(b += _)
+      cforRange(0L to n by step)(b += _)
     }
 
     List.range(0L, n + 1L, step) =? fill(n, step)
@@ -74,10 +74,10 @@ object CforSpec extends Properties("cfor") {
     List.range(0, n - 1, -step) =? fill(n, -step)
   }
 
-  property("fillList with cforRangeL using to, by (negative)") = forAll(posNum[Long], rangeL) { (n, step) =>
+  property("fillList with cforRange[Long] using to, by (negative)") = forAll(posNum[Long], rangeL) { (n, step) =>
 
     def fill(n: Long, step: Long): List[Long] = fillList { b =>
-      cforRangeL(0L to n by step)(b += _)
+      cforRange(0L to n by step)(b += _)
     }
 
     List.range(0L, n - 1, -step) =? fill(n, -step)
@@ -92,10 +92,10 @@ object CforSpec extends Properties("cfor") {
     List.range(0, n, step) =? fill(n, step)
   }
 
-  property("fillList with cforRangeL using until, by (positive)") = forAll(posNum[Long], rangeL) { (n, step) =>
+  property("fillList with cforRange[Long] using until, by (positive)") = forAll(posNum[Long], rangeL) { (n, step) =>
 
     def fill(n: Long, step: Long): List[Long] = fillList { b =>
-      cforRangeL(0L until n by step)(b += _)
+      cforRange(0L until n by step)(b += _)
     }
 
     List.range(0L, n, step) =? fill(n, step)
@@ -110,10 +110,10 @@ object CforSpec extends Properties("cfor") {
     List.range(0, n, -step) =? fill(n, -step)
   }
 
-  property("fillList with cforRangeL using until, by (negative)") = forAll(posNum[Long], rangeL) { (n, step) =>
+  property("fillList with cforRange[Long] using until, by (negative)") = forAll(posNum[Long], rangeL) { (n, step) =>
 
     def fill(n: Long, step: Long): List[Long] = fillList { b =>
-      cforRangeL(0L until n by step)(b += _)
+      cforRange(0L until n by step)(b += _)
     }
 
     List.range(0L, n, -step) =? fill(n, -step)
@@ -128,10 +128,10 @@ object CforSpec extends Properties("cfor") {
     List.range(0, n) =? fill(n)
   }
 
-  property("fillList with cforRangeL using until") = forAll(posNum[Long]) { n =>
+  property("fillList with cforRange[Long] using until") = forAll(posNum[Long]) { n =>
 
     def fill(n: Long): List[Long] = fillList { b =>
-      cforRangeL(0L until n)(b += _)
+      cforRange(0L until n)(b += _)
     }
 
     List.range(0L, n) =? fill(n)


### PR DESCRIPTION
- fixes #11 
- Currently, `cforRange` is parameterised on a union of
```
Range | NumericRange[Long]
```

- where the element type is selected with a match type on this union.
- the `cforRangeMacroGen` inspects the `quoted.Type` of the range input and appropriately selects the correct macro to expand if it is a `Range` or `NumericRange[Long]`
- Future work: potentially can revert back to two inline methods if erasure of inline methods is fixed.