### PR TITLE
Add prototype for specialisation

### DIFF
--- a/src/main/scala/spire/SpecialisationExample.scala
+++ b/src/main/scala/spire/SpecialisationExample.scala
@@ -1,0 +1,18 @@
+package spire
+
+import spire.algebra.strawman.{ CRig, Semigroup }
+import spire.math.strawman.Box
+import given spire.algebra.strawman.std.{ for CRig[Int], CRig[Long], CRig[Unit] }, Box.{ for CRig[Box[_]] }
+
+object SpecialisationExample {
+
+  inline def add[T: Semigroup](x: T, y: T): T = x + y
+  inline def two[T] given (T: CRig[T]): T = (T.one + T.one).asInstanceOf
+
+  val x = two[Box[Int]]
+  val y = two[Box[Long]]
+  val z = two[Box[Unit]]
+
+  def add2 = add(Box(1), Box(1))
+  def add3 = add(Box(2L), Box(1L))
+}

--- a/src/main/scala/spire/SpecialisationExample.scala
+++ b/src/main/scala/spire/SpecialisationExample.scala
@@ -1,18 +1,16 @@
 package spire
 
 import spire.algebra.strawman.{ CRig, Semigroup }
+import given CRig.{ _: CRig[_] }, Semigroup.{ _: Semigroup[_] }
 import spire.math.strawman.Box
 import given spire.algebra.strawman.std.{ _: CRig[Int] | CRig[Long] | CRig[Unit] }, Box.{ _: CRig[Box[_]] }
 
 object SpecialisationExample {
 
   inline def add[T: Semigroup](x: T, y: T): T = x + y
-  inline def two[T] given (T: CRig[T]): T.Param = T.one + T.one
+  inline def two[T] given (T: CRig[T]): T.Param = add(T.one, T.one)
 
   val x = two[Box[Int]]
   val y = two[Box[Long]]
   val z = two[Box[Unit]]
-
-  val add2 = add(Box(1), Box(1))
-  val add3 = add(Box(2L), Box(1L))
 }

--- a/src/main/scala/spire/SpecialisationExample.scala
+++ b/src/main/scala/spire/SpecialisationExample.scala
@@ -1,14 +1,14 @@
 package spire
 
 import spire.algebra.strawman.{ CRig, Semigroup }
-import given CRig.{ _: CRig[_] }, Semigroup.{ _: Semigroup[_] }
+import CRig.{ given CRig[?] }, Semigroup.{ given Semigroup[?] }
 import spire.math.strawman.Box
-import given spire.algebra.strawman.std.{ _: CRig[Int] | CRig[Long] | CRig[Unit] }, Box.{ _: CRig[Box[_]] }
+import spire.algebra.strawman.std.{ given CRig[Int] | CRig[Long] | CRig[Unit] }, Box.{ given CRig[Box[?]] }
 
 object SpecialisationExample {
 
   inline def add[T: Semigroup](x: T, y: T): T = x + y
-  inline def two[T] given (T: CRig[T]): T.Param = add(T.one, T.one)
+  inline def two[T](given T: CRig[T]): T.Param = add(T.one, T.one)
 
   val x = two[Box[Int]]
   val y = two[Box[Long]]

--- a/src/main/scala/spire/SpecialisationExample.scala
+++ b/src/main/scala/spire/SpecialisationExample.scala
@@ -2,7 +2,7 @@ package spire
 
 import spire.algebra.strawman.{ CRig, Semigroup }
 import spire.math.strawman.Box
-import given spire.algebra.strawman.std.{ for CRig[Int], CRig[Long], CRig[Unit] }, Box.{ for CRig[Box[_]] }
+import given spire.algebra.strawman.std.{ _: CRig[Int] | CRig[Long] | CRig[Unit] }, Box.{ _: CRig[Box[_]] }
 
 object SpecialisationExample {
 

--- a/src/main/scala/spire/SpecialisationExample.scala
+++ b/src/main/scala/spire/SpecialisationExample.scala
@@ -7,12 +7,12 @@ import given spire.algebra.strawman.std.{ for CRig[Int], CRig[Long], CRig[Unit] 
 object SpecialisationExample {
 
   inline def add[T: Semigroup](x: T, y: T): T = x + y
-  inline def two[T] given (T: CRig[T]): T = (T.one + T.one).asInstanceOf
+  inline def two[T] given (T: CRig[T]): T.Param = T.one + T.one
 
   val x = two[Box[Int]]
   val y = two[Box[Long]]
   val z = two[Box[Unit]]
 
-  def add2 = add(Box(1), Box(1))
-  def add3 = add(Box(2L), Box(1L))
+  val add2 = add(Box(1), Box(1))
+  val add3 = add(Box(2L), Box(1L))
 }

--- a/src/main/scala/spire/Tag.scala
+++ b/src/main/scala/spire/Tag.scala
@@ -5,6 +5,7 @@ import compiletime.erasedValue
 erased def erasedTag[T]: Tag[T] = erasedValue[Tag[T]]
 
 enum Tag[A] {
+
   case UnitTag    extends Tag[Unit]
   case BooleanTag extends Tag[Boolean]
   case ByteTag    extends Tag[Byte]
@@ -14,6 +15,18 @@ enum Tag[A] {
   case FloatTag   extends Tag[Float]
   case DoubleTag  extends Tag[Double]
   case AnyTag[A]  extends Tag[A]
+
+  def render[T]: String = this match {
+    case UnitTag    => "Unit"
+    case BooleanTag => "Boolean"
+    case ByteTag    => "Byte"
+    case ShortTag   => "Short"
+    case IntTag     => "Int"
+    case LongTag    => "Long"
+    case FloatTag   => "Float"
+    case DoubleTag  => "Double"
+    case AnyTag()   => "Any"
+  }
 }
 
 object Tag {
@@ -27,20 +40,6 @@ object Tag {
   given as Tag[Float]   = FloatTag
   given as Tag[Double]  = DoubleTag
   given [A] as Tag[A]   = AnyTag()
-
-  given {
-    def (tag: Tag[T]) render[T]: String = tag match {
-      case UnitTag    => "Unit"
-      case BooleanTag => "Boolean"
-      case ByteTag    => "Byte"
-      case ShortTag   => "Short"
-      case IntTag     => "Int"
-      case LongTag    => "Long"
-      case FloatTag   => "Float"
-      case DoubleTag  => "Double"
-      case AnyTag()   => "Any"
-    }
-  }
 
   inline def apply[T: Tag] = the[Tag[T]]
 

--- a/src/main/scala/spire/Tag.scala
+++ b/src/main/scala/spire/Tag.scala
@@ -31,16 +31,16 @@ enum Tag[A] {
 
 object Tag {
 
-  given as Tag[Unit]    = UnitTag
-  given as Tag[Boolean] = BooleanTag
-  given as Tag[Byte]    = ByteTag
-  given as Tag[Short]   = ShortTag
-  given as Tag[Int]     = IntTag
-  given as Tag[Long]    = LongTag
-  given as Tag[Float]   = FloatTag
-  given as Tag[Double]  = DoubleTag
-  given [A] as Tag[A]   = AnyTag()
+  given Tag[Unit]    = UnitTag
+  given Tag[Boolean] = BooleanTag
+  given Tag[Byte]    = ByteTag
+  given Tag[Short]   = ShortTag
+  given Tag[Int]     = IntTag
+  given Tag[Long]    = LongTag
+  given Tag[Float]   = FloatTag
+  given Tag[Double]  = DoubleTag
+  given [A]: Tag[A]  = AnyTag()
 
-  inline def apply[T: Tag] = the[Tag[T]]
+  inline def apply[T: Tag] = summon[Tag[T]]
 
 }

--- a/src/main/scala/spire/Tag.scala
+++ b/src/main/scala/spire/Tag.scala
@@ -6,15 +6,15 @@ erased def erasedTag[T]: Tag[T] = erasedValue[Tag[T]]
 
 enum Tag[A] {
 
-  case UnitTag    extends Tag[Unit]
-  case BooleanTag extends Tag[Boolean]
-  case ByteTag    extends Tag[Byte]
-  case ShortTag   extends Tag[Short]
-  case IntTag     extends Tag[Int]
-  case LongTag    extends Tag[Long]
-  case FloatTag   extends Tag[Float]
-  case DoubleTag  extends Tag[Double]
-  case AnyTag[A]  extends Tag[A]
+  case UnitTag     extends Tag[Unit]
+  case BooleanTag  extends Tag[Boolean]
+  case ByteTag     extends Tag[Byte]
+  case ShortTag    extends Tag[Short]
+  case IntTag      extends Tag[Int]
+  case LongTag     extends Tag[Long]
+  case FloatTag    extends Tag[Float]
+  case DoubleTag   extends Tag[Double]
+  case AnyTag[A]() extends Tag[A]
 
   def render[T]: String = this match {
     case UnitTag    => "Unit"

--- a/src/main/scala/spire/Tag.scala
+++ b/src/main/scala/spire/Tag.scala
@@ -2,32 +2,46 @@ package spire
 
 import compiletime.erasedValue
 
-erased def tag[T]: Tag[T] = erasedValue[Tag[T]]
+erased def erasedTag[T]: Tag[T] = erasedValue[Tag[T]]
 
 enum Tag[A] {
-  case UnitTag              extends Tag[Unit]
-  case BooleanTag           extends Tag[Boolean]
-  case ByteTag              extends Tag[Byte]
-  case ShortTag             extends Tag[Short]
-  case IntTag               extends Tag[Int]
-  case LongTag              extends Tag[Long]
-  case FloatTag             extends Tag[Float]
-  case DoubleTag            extends Tag[Double]
-  case RefTag[A <: AnyRef]  extends Tag[A]
+  case UnitTag    extends Tag[Unit]
+  case BooleanTag extends Tag[Boolean]
+  case ByteTag    extends Tag[Byte]
+  case ShortTag   extends Tag[Short]
+  case IntTag     extends Tag[Int]
+  case LongTag    extends Tag[Long]
+  case FloatTag   extends Tag[Float]
+  case DoubleTag  extends Tag[Double]
+  case AnyTag[A]  extends Tag[A]
 }
 
 object Tag {
 
-  given as Tag[Unit]            = UnitTag
-  given as Tag[Boolean]         = BooleanTag
-  given as Tag[Byte]            = ByteTag
-  given as Tag[Short]           = ShortTag
-  given as Tag[Int]             = IntTag
-  given as Tag[Long]            = LongTag
-  given as Tag[Float]           = FloatTag
-  given as Tag[Double]          = DoubleTag
-  given [A <: AnyRef] as Tag[A] = RefTag()
+  given as Tag[Unit]    = UnitTag
+  given as Tag[Boolean] = BooleanTag
+  given as Tag[Byte]    = ByteTag
+  given as Tag[Short]   = ShortTag
+  given as Tag[Int]     = IntTag
+  given as Tag[Long]    = LongTag
+  given as Tag[Float]   = FloatTag
+  given as Tag[Double]  = DoubleTag
+  given [A] as Tag[A]   = AnyTag()
 
-  inline def apply[T: Tag]      = the[Tag[T]]
+  given {
+    def (tag: Tag[T]) render[T]: String = tag match {
+      case UnitTag    => "Unit"
+      case BooleanTag => "Boolean"
+      case ByteTag    => "Byte"
+      case ShortTag   => "Short"
+      case IntTag     => "Int"
+      case LongTag    => "Long"
+      case FloatTag   => "Float"
+      case DoubleTag  => "Double"
+      case AnyTag()   => "Any"
+    }
+  }
+
+  inline def apply[T: Tag] = the[Tag[T]]
 
 }

--- a/src/main/scala/spire/Tag.scala
+++ b/src/main/scala/spire/Tag.scala
@@ -1,0 +1,33 @@
+package spire
+
+import compiletime.erasedValue
+
+erased def tag[T]: Tag[T] = erasedValue[Tag[T]]
+
+enum Tag[A] {
+  case UnitTag              extends Tag[Unit]
+  case BooleanTag           extends Tag[Boolean]
+  case ByteTag              extends Tag[Byte]
+  case ShortTag             extends Tag[Short]
+  case IntTag               extends Tag[Int]
+  case LongTag              extends Tag[Long]
+  case FloatTag             extends Tag[Float]
+  case DoubleTag            extends Tag[Double]
+  case RefTag[A <: AnyRef]  extends Tag[A]
+}
+
+object Tag {
+
+  given as Tag[Unit]            = UnitTag
+  given as Tag[Boolean]         = BooleanTag
+  given as Tag[Byte]            = ByteTag
+  given as Tag[Short]           = ShortTag
+  given as Tag[Int]             = IntTag
+  given as Tag[Long]            = LongTag
+  given as Tag[Float]           = FloatTag
+  given as Tag[Double]          = DoubleTag
+  given [A <: AnyRef] as Tag[A] = RefTag()
+
+  inline def apply[T: Tag]      = the[Tag[T]]
+
+}

--- a/src/main/scala/spire/algebra/strawman/CRig.scala
+++ b/src/main/scala/spire/algebra/strawman/CRig.scala
@@ -5,10 +5,14 @@ import spire.{ Tag, erasedTag }
 /**CRig as a match type, allowing for use site specialisation of the type parameter.
  * - does cause issues with unification of the type parameter T needing casts, until another way is found.
  */
-type CRig[T] <: CRigs.CRig[_] = T match {
+type CRig[T] <: CRigs.CRig[?] = T match {
   case Int  => CRigs.Specialised.IntCRig
   case Long => CRigs.Specialised.LongCRig
   case _    => CRigs.CRig[T]
+}
+
+object CRig {
+  inline given [T] as CRig[T.Param] given (T: CRig[T]) = T.asInstanceOf
 }
 
 object CRigs {

--- a/src/main/scala/spire/algebra/strawman/CRig.scala
+++ b/src/main/scala/spire/algebra/strawman/CRig.scala
@@ -12,7 +12,7 @@ type CRig[T] <: CRigs.CRig[?] = T match {
 }
 
 object CRig {
-  inline given [T] as CRig[T.Param] given (T: CRig[T]) = T.asInstanceOf
+  inline given [T](given T: CRig[T]): CRig[T.Param] = T.asInstanceOf
 }
 
 object CRigs {

--- a/src/main/scala/spire/algebra/strawman/CRig.scala
+++ b/src/main/scala/spire/algebra/strawman/CRig.scala
@@ -1,0 +1,40 @@
+package spire.algebra.strawman
+
+import spire.{ Tag, tag }
+
+/**CRig as a match type, allowing for use site specialisation of the type parameter.
+ * - does cause issues with unification of the type parameter T needing casts, until another way is found.
+ */
+type CRig[T] <: CRigs.CRig[_] = T match {
+  case Int  => CRigs.Specialised.IntCRig
+  case Long => CRigs.Specialised.LongCRig
+  case _    => CRigs.CRig[T]
+}
+
+object CRigs {
+
+  trait CRig[A] extends Semigroups.Semigroup[A] {
+
+    inline def (x: T) * [T] (y: T): T = inline tag[T] match { case _: Tag[A] =>
+      x times y
+    }
+
+    def zero: A
+    def one: A
+    def (x: A) times (y: A): A
+
+  }
+
+  object Specialised {
+    trait IntCRig extends CRig[Int] {
+      def zero: Int
+      def one: Int
+      def (x: Int) times (y: Int): Int
+    }
+    trait LongCRig extends CRig[Long] {
+      def zero: Long
+      def one: Long
+      def (x: Long) times (y: Long): Long
+    }
+  }
+}

--- a/src/main/scala/spire/algebra/strawman/CRig.scala
+++ b/src/main/scala/spire/algebra/strawman/CRig.scala
@@ -1,6 +1,6 @@
 package spire.algebra.strawman
 
-import spire.{ Tag, tag }
+import spire.{ Tag, erasedTag }
 
 /**CRig as a match type, allowing for use site specialisation of the type parameter.
  * - does cause issues with unification of the type parameter T needing casts, until another way is found.
@@ -15,7 +15,7 @@ object CRigs {
 
   trait CRig[A] extends Semigroups.Semigroup[A] {
 
-    inline def (x: T) * [T] (y: T): T = inline tag[T] match { case _: Tag[A] =>
+    inline def (x: T) * [T] (y: T): T = inline erasedTag[T] match { case _: Tag[A] =>
       x times y
     }
 
@@ -26,12 +26,12 @@ object CRigs {
   }
 
   object Specialised {
-    trait IntCRig extends CRig[Int] {
+    trait IntCRig extends CRig[Int], Semigroup[Int] {
       def zero: Int
       def one: Int
       def (x: Int) times (y: Int): Int
     }
-    trait LongCRig extends CRig[Long] {
+    trait LongCRig extends CRig[Long], Semigroup[Long] {
       def zero: Long
       def one: Long
       def (x: Long) times (y: Long): Long

--- a/src/main/scala/spire/algebra/strawman/Semigroup.scala
+++ b/src/main/scala/spire/algebra/strawman/Semigroup.scala
@@ -1,6 +1,6 @@
 package spire.algebra.strawman
 
-import spire.{ Tag, tag }
+import spire.{ Tag, erasedTag }
 
 /**Semigroup as a match type, allowing for use site specialisation of the type parameter.
  * - does cause issues with unification of the type parameter T needing casts, until another way is found.
@@ -15,7 +15,9 @@ object Semigroups {
 
   trait Semigroup[A] {
 
-    inline def (x: T) + [T] (y: T): T = inline tag[T] match { case _: Tag[A] =>
+    final type Param = A
+
+    inline def (x: T) + [T] (y: T): T = inline erasedTag[T] match { case _: Tag[A] =>
       x plus y
     }
 

--- a/src/main/scala/spire/algebra/strawman/Semigroup.scala
+++ b/src/main/scala/spire/algebra/strawman/Semigroup.scala
@@ -5,10 +5,14 @@ import spire.{ Tag, erasedTag }
 /**Semigroup as a match type, allowing for use site specialisation of the type parameter.
  * - does cause issues with unification of the type parameter T needing casts, until another way is found.
  */
-type Semigroup[T] <: Semigroups.Semigroup[_] = T match {
+type Semigroup[T] <: Semigroups.Semigroup[?] = T match {
   case Int  => Semigroups.Specialised.IntSemigroup
   case Long => Semigroups.Specialised.LongSemigroup
   case _    => Semigroups.Semigroup[T]
+}
+
+object Semigroup {
+  inline given [T] as Semigroup[T.Param] given (T: Semigroup[T]) = T.asInstanceOf
 }
 
 object Semigroups {

--- a/src/main/scala/spire/algebra/strawman/Semigroup.scala
+++ b/src/main/scala/spire/algebra/strawman/Semigroup.scala
@@ -12,7 +12,7 @@ type Semigroup[T] <: Semigroups.Semigroup[?] = T match {
 }
 
 object Semigroup {
-  inline given [T] as Semigroup[T.Param] given (T: Semigroup[T]) = T.asInstanceOf
+  inline given [T](given T: Semigroup[T]): Semigroup[T.Param] = T.asInstanceOf
 }
 
 object Semigroups {

--- a/src/main/scala/spire/algebra/strawman/Semigroup.scala
+++ b/src/main/scala/spire/algebra/strawman/Semigroup.scala
@@ -1,0 +1,34 @@
+package spire.algebra.strawman
+
+import spire.{ Tag, tag }
+
+/**Semigroup as a match type, allowing for use site specialisation of the type parameter.
+ * - does cause issues with unification of the type parameter T needing casts, until another way is found.
+ */
+type Semigroup[T] <: Semigroups.Semigroup[_] = T match {
+  case Int  => Semigroups.Specialised.IntSemigroup
+  case Long => Semigroups.Specialised.LongSemigroup
+  case _    => Semigroups.Semigroup[T]
+}
+
+object Semigroups {
+
+  trait Semigroup[A] {
+
+    inline def (x: T) + [T] (y: T): T = inline tag[T] match { case _: Tag[A] =>
+      x plus y
+    }
+
+    def (x: A) plus (y: A): A
+
+  }
+
+  object Specialised {
+    trait IntSemigroup extends Semigroup[Int] {
+      def (x: Int) plus (y: Int): Int
+    }
+    trait LongSemigroup extends Semigroup[Long] {
+      def (x: Long) plus (y: Long): Long
+    }
+  }
+}

--- a/src/main/scala/spire/algebra/strawman/std/package.scala
+++ b/src/main/scala/spire/algebra/strawman/std/package.scala
@@ -1,0 +1,24 @@
+package spire.algebra.strawman.std
+
+import spire.algebra.strawman.{ CRig, Semigroup }
+
+given as CRig[Int], Semigroup[Int] {
+  def zero  = 0
+  def one   = 1
+  def (x: Int) plus  (y: Int) = x + y
+  def (x: Int) times (y: Int) = x * y
+}
+
+given as CRig[Long], Semigroup[Long] {
+  def zero = 0L
+  def one  = 1L
+  def (x: Long) plus  (y: Long) = x + y
+  def (x: Long) times (y: Long) = x * y
+}
+
+given as CRig[Unit], Semigroup[Unit] {
+  def zero = ()
+  def one  = ()
+  def (x: Unit) plus  (y: Unit) = ()
+  def (x: Unit) times (y: Unit) = ()
+}

--- a/src/main/scala/spire/algebra/strawman/std/package.scala
+++ b/src/main/scala/spire/algebra/strawman/std/package.scala
@@ -2,21 +2,21 @@ package spire.algebra.strawman.std
 
 import spire.algebra.strawman.CRig
 
-given as CRig[Int] {
+given CRig[Int] {
   def zero  = 0
   def one   = 1
   def (x: Int) plus  (y: Int) = x + y
   def (x: Int) times (y: Int) = x * y
 }
 
-given as CRig[Long] {
+given CRig[Long] {
   def zero = 0L
   def one  = 1L
   def (x: Long) plus  (y: Long) = x + y
   def (x: Long) times (y: Long) = x * y
 }
 
-given as CRig[Unit] {
+given CRig[Unit] {
   def zero = ()
   def one  = ()
   def (x: Unit) plus  (y: Unit) = ()

--- a/src/main/scala/spire/algebra/strawman/std/package.scala
+++ b/src/main/scala/spire/algebra/strawman/std/package.scala
@@ -1,22 +1,22 @@
 package spire.algebra.strawman.std
 
-import spire.algebra.strawman.{ CRig, Semigroup }
+import spire.algebra.strawman.CRig
 
-given as CRig[Int], Semigroup[Int] {
+given as CRig[Int] {
   def zero  = 0
   def one   = 1
   def (x: Int) plus  (y: Int) = x + y
   def (x: Int) times (y: Int) = x * y
 }
 
-given as CRig[Long], Semigroup[Long] {
+given as CRig[Long] {
   def zero = 0L
   def one  = 1L
   def (x: Long) plus  (y: Long) = x + y
   def (x: Long) times (y: Long) = x * y
 }
 
-given as CRig[Unit], Semigroup[Unit] {
+given as CRig[Unit] {
   def zero = ()
   def one  = ()
   def (x: Unit) plus  (y: Unit) = ()

--- a/src/main/scala/spire/math/strawman/Box.scala
+++ b/src/main/scala/spire/math/strawman/Box.scala
@@ -1,0 +1,48 @@
+package spire.math.strawman
+
+import spire.Tag
+import spire.algebra.strawman.{ CRig, Semigroup }
+
+sealed trait Box[T] {
+  def +(y: Box[T]) given Semigroup[T]: Box[T]
+  def *(y: Box[T]) given CRig[T]: Box[T]
+}
+
+object Box {
+  import Tag._
+
+  given [T: Semigroup: CRig: Tag] as CRig[Box[T]], Semigroup[Box[T]] {
+    val zero = point(the[CRig[T]].zero.asInstanceOf[T])
+    val one  = point(the[CRig[T]].one.asInstanceOf[T])
+    def (x: Box[T]) plus (y: Box[T]): Box[T]  = x + y
+    def (x: Box[T]) times (y: Box[T]): Box[T] = x * y
+  }
+
+  def apply(i: Int):  Box[Int]  = Box.species(i, "Int")
+  def apply(l: Long): Box[Long] = Box.species(l, "Long")
+  def apply[A](a: A): Box[A]    = Box.species(a, "A")
+
+  private def point[A: Tag](f: A): Box[A] = Tag[A] match {
+    case IntTag  => Box(f)
+    case LongTag => Box(f)
+    case t       => Box(f)
+  }
+
+  inline private def species[T](t: T, inline kind: String): Box[T] = {
+
+    class BoxT(val x: T) extends Box[T] {
+
+      def + (box: Box[T]) given Semigroup[T]: BoxT = (box: @unchecked) match { case box: BoxT =>
+        BoxT(x + box.x)
+      }
+
+      def * (box: Box[T]) given CRig[T]: BoxT = (box: @unchecked) match { case box: BoxT =>
+        BoxT(x * box.x)
+      }
+
+      override def toString = s"Box$kind($x)"
+    }
+
+    BoxT(t)
+  }
+}

--- a/src/main/scala/spire/math/strawman/Box.scala
+++ b/src/main/scala/spire/math/strawman/Box.scala
@@ -4,16 +4,16 @@ import spire.Tag
 import spire.algebra.strawman.{ CRig, Semigroup }
 
 sealed trait Box[T] {
-  def +(y: Box[T]) given Semigroup[T]: Box[T]
-  def *(y: Box[T]) given CRig[T]: Box[T]
+  def +(y: Box[T]) (given Semigroup[T]): Box[T]
+  def *(y: Box[T]) (given CRig[T]): Box[T]
 }
 
 object Box {
   import Tag._
 
-  given [T: CRig: Tag] as CRig[Box[T]], Semigroup[Box[T]] {
-    val zero = point(the[CRig[T]].zero.asInstanceOf[T]) // must use runtime tag
-    val one  = point(the[CRig[T]].one.asInstanceOf[T])  // must use runtime tag
+  given [T: CRig: Tag]: CRig[Box[T]], Semigroup[Box[T]] {
+    val zero = point(summon[CRig[T]].zero.asInstanceOf[T]) // must use runtime tag
+    val one  = point(summon[CRig[T]].one.asInstanceOf[T])  // must use runtime tag
     def (x: Box[T]) plus (y: Box[T]): Box[T]  = x + y
     def (x: Box[T]) times (y: Box[T]): Box[T] = x * y
   }
@@ -28,12 +28,12 @@ object Box {
     case _       => Box(a)
   }
 
-  inline private def species[T](t: T) given (tag: => Tag[T]): Box[T] = {
+  inline private def species[T](t: T) (given tag: => Tag[T]): Box[T] = {
 
     class BoxT(val x: T) extends Box[T] {
 
-      def + (box: Box[T]) given Semigroup[T] : BoxT = BoxT(x + box.asInstanceOf[BoxT].x)
-      def * (box: Box[T]) given CRig[T]      : BoxT = BoxT(x * box.asInstanceOf[BoxT].x)
+      def + (box: Box[T]) (given Semigroup[T]) : BoxT = BoxT(x + box.asInstanceOf[BoxT].x)
+      def * (box: Box[T]) (given CRig[T])      : BoxT = BoxT(x * box.asInstanceOf[BoxT].x)
 
       override def toString = s"Box${tag.render}($x)"
     }


### PR DESCRIPTION
fixes #22 

- introduces GADT `Tag[T]`, used as both as erased and reified values in order to select specialised methods without casting.
- a private `inline` method is used to specialise a template class for the number type `Box[T]`
- match types are used to select specialised versions of traits based on the parameter
  - this introduces an issue with the unification of the type parameters for the specialised type classes. This is resolved with a final type member of a type class to mirror its type parameter and inline givens for that type member given evidence of a type class for the parameter.