### PR TITLE
Implement Generic Number literals for fields and crings

### DIFF
--- a/src/main/scala/spire/algebra/Field.scala
+++ b/src/main/scala/spire/algebra/Field.scala
@@ -30,11 +30,14 @@ trait Field[@sp(Int, Long, Float, Double) A] extends CRing[A] { self =>
   }
 
   def fromBigDecimal(n: BigDecimal): A = {
-    val quot     = fromBigInt(n.quot(Field.one).toBigInt)
-    val remRaw   = n.remainder(Field.one)
-    val unscaled = fromBigInt(remRaw.underlying.unscaledValue)
-    val scalePow = fromBigInt(JBigDecimal(scala.math.pow(10.0, remRaw.scale.toDouble)).toBigInteger)
-    plus(quot, div(unscaled, scalePow))
+    val quot = fromBigInt(n.quot(Field.one).toBigInt)
+    if n.isWhole then
+      quot
+    else
+      val remRaw   = n.remainder(Field.one)
+      val unscaled = fromBigInt(remRaw.underlying.unscaledValue)
+      val scalePow = fromBigInt(JBigDecimal(scala.math.pow(10.0, remRaw.scale.toDouble)).toBigInteger)
+      plus(quot, div(unscaled, scalePow))
   }
 
 }
@@ -51,6 +54,5 @@ trait FieldFunctions[F[T] <: Field[T]] extends CRingFunctions[F] {
 
 object Field extends FieldFunctions[Field] {
   private val one: BigDecimal = 1
-  private val two: BigDecimal = 2
   inline def apply[A] (given Field[A]) = summon[Field[A]]
 }

--- a/src/main/scala/spire/syntax/Literals.scala
+++ b/src/main/scala/spire/syntax/Literals.scala
@@ -3,18 +3,76 @@ package syntax
 
 import spire.algebra.{Field, CRing}
 
+import scala.quoted._
+import scala.quoted.matching._
+import scala.util.FromDigits
+
 object primitives {
 
-  inline def (n: Int) as [A] (given ev: CRing[A]): A = inline n match {
-    case 0 => ev.zero
-    case 1 => ev.one
-    case n => ev.fromInt(n)
-  }
+  inline def (n: => Int) as [A] (given A: CRing[A]): A = inline n match
+    case 0 => A.zero
+    case 1 => A.one
+    case n => A.fromInt(n)
 
-  inline def (n: Double) as [A] (given ev: Field[A]): A = inline n match {
-    case 0 => ev.zero
-    case 1 => ev.one
-    case n => ev.fromDouble(n)
-  }
+  inline def (n: => Double) as [A] (given A: Field[A]): A = inline n match
+    case 0 => A.zero
+    case 1 => A.one
+    case n => A.fromDouble(n)
+
+  private inline def ringFromBigInt[A](digits: String, radix: Int)(given A: CRing[A]) =
+    A.fromBigInt(summon[FromDigits[BigInt]].fromDigits(digits, radix))
+
+  private inline def fieldFromBigDecimal[A](digits: String)(given A: Field[A]) =
+    A.fromBigDecimal(summon[FromDigits[BigDecimal]].fromDigits(digits))
+
+  class RingLiteral[A](given CRing[A]) extends FromDigits.WithRadix[A]
+    def fromDigits(digits: String, radix: Int): A = ringFromBigInt(digits, radix)
+
+  class FieldLiteral[A](given Field[A]) extends FromDigits.Floating[A]
+    def fromDigits(digits: String): A = fieldFromBigDecimal(digits)
+
+  given [A](given ev: CRing[A]): RingLiteral[A]
+    override inline def fromDigits(digits: String, radix: Int): A =
+      ${ fromRingImpl('digits, 'radix, 'ev) }
+
+  given [A](given ev: Field[A]): FieldLiteral[A]
+    override inline def fromDigits(digits: String): A =
+      ${ fromFieldImpl('digits, 'ev) }
+
+  def fromRingImpl[A: Type](digits: Expr[String], radix: Expr[Int], ring: Expr[CRing[A]])(given qctx: QuoteContext): Expr[A] =
+    (digits, radix) match
+    case (Const(ds), Const(r)) =>
+      try
+        FromDigits.intFromDigits(ds, r) match
+          case 0 => '{ $ring.zero }
+          case 1 => '{ $ring.one }
+          case n => '{ $ring.fromInt(${Expr(n)}) }
+      catch
+        case e: (FromDigits.NumberTooLarge | FromDigits.MalformedNumber) =>
+          '{ ringFromBigInt($digits, $radix)(given $ring) }
+    case _ => '{ ringFromBigInt($digits, $radix)(given $ring) }
+
+  def fromFieldImpl[A: Type](digits: Expr[String], field: Expr[Field[A]])(given qctx: QuoteContext): Expr[A] =
+    digits match
+    case Const(ds) =>
+      try
+        FromDigits.intFromDigits(ds) match
+          case 0 => '{ $field.zero }
+          case 1 => '{ $field.one }
+          case n => '{ $field.fromInt(${Expr(n)}) }
+      catch
+        case e: (FromDigits.NumberTooLarge | FromDigits.MalformedNumber) =>
+          if """.*[.eE].*""".r.matches(ds) then
+            if BigDecimal(ds).isDecimalDouble then
+              FromDigits.doubleFromDigits(ds) match
+                case 0.0 => '{ $field.zero }
+                case 1.0 => '{ $field.one }
+                case n   => '{ $field.fromDouble(${Expr(n)}) }
+            else
+              '{ fieldFromBigDecimal($digits)(given $field) }
+          else
+            '{ ringFromBigInt($digits, ${Expr(10)})(given $field) }
+
+    case _ => '{ fieldFromBigDecimal($digits)(given $field) }
 
 }

--- a/src/test/scala/spire/GenericLiterals.scala
+++ b/src/test/scala/spire/GenericLiterals.scala
@@ -1,0 +1,13 @@
+package spire
+
+import spire.syntax.primitives.given
+import spire.math.Rat
+
+object GenericLiterals {
+  val planck: Rat   = 662607015e-35
+  val precise: Rat  = 6626070157483679999e-50
+  val one: Rat      = 1
+  val zero: Rat     = 0.0
+  val big: Rat      = 37237283824892382
+  val n: Rat        = 66260701574374783247326472374237846732747999999e35
+}


### PR DESCRIPTION
fixes #27 

Any type with an available CRing or Field can import `spire.syntax.primitives.given` to benefit from generic number literals, these inline to the zero, one, fromInt, fromDouble, fromBigInt, fromBigDecimal where appropriate.

Also fixed a bug where a whole number passed to fromBigDecimal fails at runtime.