### PR TITLE
remove implicit, refactor literals, ensure precision with fromDouble

### DIFF
--- a/src/main/scala/spire/Example.scala
+++ b/src/main/scala/spire/Example.scala
@@ -1,7 +1,7 @@
 package spire
 
 import spire.algebra.Order
-import spire.implicits.{given Order[Int]}
+import spire.instances.{given Order[Int]}
 
 object Example extends App {
   val array = Array(2, 3, 1, 4)

--- a/src/main/scala/spire/algebra/CRig.scala
+++ b/src/main/scala/spire/algebra/CRig.scala
@@ -23,12 +23,12 @@ trait CRig[@sp(Int, Long, Float, Double) A] {
   /**
     * Tests if `a` is zero.
     */
-  def isZero(a: A) (given ev: Eq[A]): Boolean = ev.eqv(a, zero)
+  def isZero(a: A)(given ev: Eq[A]): Boolean = ev.eqv(a, zero)
 
   /**
     * Tests if `a` is one.
     */
-  def isOne(a: A) (given ev: Eq[A]): Boolean = ev.eqv(a, one)
+  def isOne(a: A)(given ev: Eq[A]): Boolean = ev.eqv(a, one)
 
   // Additional methods
 
@@ -50,29 +50,29 @@ trait CRig[@sp(Int, Long, Float, Double) A] {
 
 trait CRigFunctions[C[T] <: CRig[T]] {
 
-  def plus[@sp(Int, Long, Float, Double) A](x: A, y: A) (given ev: C[A]): A =
+  def plus[@sp(Int, Long, Float, Double) A](x: A, y: A)(given ev: C[A]): A =
     ev.plus(x, y)
 
-  def times[@sp(Int, Long, Float, Double) A](x: A, y: A) (given ev: C[A]): A =
+  def times[@sp(Int, Long, Float, Double) A](x: A, y: A)(given ev: C[A]): A =
     ev.times(x, y)
 
-  def zero[@sp(Int, Long, Float, Double) A] (given ev: C[A]): A =
+  def zero[@sp(Int, Long, Float, Double) A](given ev: C[A]): A =
     ev.zero
 
-  def one[@sp(Int, Long, Float, Double) A] (given ev: C[A]): A =
+  def one[@sp(Int, Long, Float, Double) A](given ev: C[A]): A =
     ev.one
 
-  def isZero[@sp(Int, Long, Float, Double) A](a: A) (given ev0: C[A], ev1: Eq[A]): Boolean =
+  def isZero[@sp(Int, Long, Float, Double) A](a: A)(given ev0: C[A], ev1: Eq[A]): Boolean =
     ev0.isZero(a)
 
-  def isOne[@sp(Int, Long, Float, Double) A](a: A) (given ev0: C[A], ev1: Eq[A]): Boolean =
+  def isOne[@sp(Int, Long, Float, Double) A](a: A)(given ev0: C[A], ev1: Eq[A]): Boolean =
     ev0.isOne(a)
 
-  def sumN[@sp(Int, Long, Float, Double) A](a: A, n: Int) (given ev: C[A]): A =
+  def sumN[@sp(Int, Long, Float, Double) A](a: A, n: Int)(given ev: C[A]): A =
     ev.sumN(a, n)
 
 }
 
 object CRig extends CRigFunctions[CRig] {
-  inline def apply[A] (given CRig[A]) = summon[CRig[A]]
+  inline def apply[A](given CRig[A]) = summon[CRig[A]]
 }

--- a/src/main/scala/spire/algebra/CRing.scala
+++ b/src/main/scala/spire/algebra/CRing.scala
@@ -65,20 +65,20 @@ trait CRing[@sp(Int, Long, Float, Double) A] extends CRig[A] {
 
 trait CRingFunctions[C[T] <: CRing[T]] extends CRigFunctions[C] {
 
-  def negate[@sp(Int, Long, Float, Double) A](x: A) (given ev: C[A]): A =
+  def negate[@sp(Int, Long, Float, Double) A](x: A)(given ev: C[A]): A =
     ev.negate(x)
 
-  def minus[@sp(Int, Long, Float, Double) A](x: A, y: A) (given ev: C[A]): A =
+  def minus[@sp(Int, Long, Float, Double) A](x: A, y: A)(given ev: C[A]): A =
     ev.minus(x, y)
 
-  def fromInt[@sp(Int, Long, Float, Double) A](n: Int) (given ev: C[A]): A =
+  def fromInt[@sp(Int, Long, Float, Double) A](n: Int)(given ev: C[A]): A =
     ev.fromInt(n)
 
-  def fromBigInt[@sp(Int, Long, Float, Double) A](n: BigInt) (given ev: C[A]): A =
+  def fromBigInt[@sp(Int, Long, Float, Double) A](n: BigInt)(given ev: C[A]): A =
     ev.fromBigInt(n)
 
 }
 
 object CRing extends CRingFunctions[CRing] {
-  inline def apply[A] (given CRing[A]) = summon[CRing[A]]
+  inline def apply[A](given CRing[A]) = summon[CRing[A]]
 }

--- a/src/main/scala/spire/algebra/Eq.scala
+++ b/src/main/scala/spire/algebra/Eq.scala
@@ -23,10 +23,10 @@ trait Eq[@sp A] { self =>
 
 abstract class EqFunctions[E[T] <: Eq[T]] {
 
-  def eqv[@sp A](x: A, y: A) (given ev: E[A]): Boolean =
+  def eqv[@sp A](x: A, y: A)(given ev: E[A]): Boolean =
     ev.eqv(x, y)
 
-  def neqv[@sp A](x: A, y: A) (given ev: E[A]): Boolean =
+  def neqv[@sp A](x: A, y: A)(given ev: E[A]): Boolean =
     ev.neqv(x, y)
 
 }
@@ -34,15 +34,15 @@ abstract class EqFunctions[E[T] <: Eq[T]] {
 object Eq extends EqFunctions[Eq] {
 
   /**
-   * Access an implicit `Eq[A]`.
+   * Access a given `Eq[A]`.
    */
-  inline def apply[A] (given Eq[A]) = summon[Eq[A]]
+  inline def apply[A](given Eq[A]) = summon[Eq[A]]
 
   /**
-   * Convert an implicit `Eq[B]` to an `Eq[A]` using the given
+   * Convert a given `Eq[B]` to an `Eq[A]` using the given
    * function `f`.
    */
-  def by[@sp A, @sp B](f: A => B) (given ev: Eq[B]): Eq[A] =
+  def by[@sp A, @sp B](f: A => B)(given ev: Eq[B]): Eq[A] =
     new Eq[A] {
       def eqv(x: A, y: A) = ev.eqv(f(x), f(y))
     }

--- a/src/main/scala/spire/algebra/Field.scala
+++ b/src/main/scala/spire/algebra/Field.scala
@@ -14,22 +14,16 @@ trait Field[@sp(Int, Long, Float, Double) A] extends CRing[A] { self =>
 
   def reciprocal(x: A): A = div(one, x)
 
-  def fromDouble(n: Double): A = {
-    if n.isValidInt then {
-      fromInt(n.toInt)
-    }
-    else if n.isWhole then {
-      if (n < 0 && n >= Long.MinValue) || (n > 0 && n <= Long.MaxValue) then
-        fromBigInt(BigInt(n.toLong))
+  def fromDouble(n: Double): A =
+    if n.isWhole then
+      if n.isValidInt then
+        fromInt(n.toInt)
       else
         fromBigInt(JBigDecimal(n).toBigInteger)
-    }
-    else {
+    else
       fromBigDecimal(BigDecimal(n))
-    }
-  }
 
-  def fromBigDecimal(n: BigDecimal): A = {
+  def fromBigDecimal(n: BigDecimal): A =
     val quot = fromBigInt(n.quot(Field.one).toBigInt)
     if n.isWhole then
       quot
@@ -38,21 +32,20 @@ trait Field[@sp(Int, Long, Float, Double) A] extends CRing[A] { self =>
       val unscaled = fromBigInt(remRaw.underlying.unscaledValue)
       val scalePow = fromBigInt(JBigDecimal(scala.math.pow(10.0, remRaw.scale.toDouble)).toBigInteger)
       plus(quot, div(unscaled, scalePow))
-  }
 
 }
 
 trait FieldFunctions[F[T] <: Field[T]] extends CRingFunctions[F] {
 
-  def reciprocal[@sp(Int, Long, Float, Double) A](x: A) (given ev: F[A]): A =
+  def reciprocal[@sp(Int, Long, Float, Double) A](x: A)(given ev: F[A]): A =
     ev.reciprocal(x)
 
-  def div[@sp(Int, Long, Float, Double) A](x: A, y: A) (given ev: F[A]): A =
+  def div[@sp(Int, Long, Float, Double) A](x: A, y: A)(given ev: F[A]): A =
     ev.div(x, y)
 
 }
 
 object Field extends FieldFunctions[Field] {
   private val one: BigDecimal = 1
-  inline def apply[A] (given Field[A]) = summon[Field[A]]
+  inline def apply[A](given Field[A]) = summon[Field[A]]
 }

--- a/src/main/scala/spire/algebra/Order.scala
+++ b/src/main/scala/spire/algebra/Order.scala
@@ -77,7 +77,7 @@ trait Order[@sp A] extends PartialOrder[A] { self =>
 
 abstract class OrderFunctions[O[T] <: Order[T]] extends PartialOrderFunctions[O] {
 
-  def compare[@sp A](x: A, y: A) (given ev: O[A]): Int =
+  def compare[@sp A](x: A, y: A)(given ev: O[A]): Int =
     ev.compare(x, y)
 
 }
@@ -85,15 +85,15 @@ abstract class OrderFunctions[O[T] <: Order[T]] extends PartialOrderFunctions[O]
 object Order extends OrderFunctions[Order] {
 
   /**
-   * Access an implicit `Order[A]`.
+   * Access a given `Order[A]`.
    */
-  inline def apply[A] (given Order[A]) = summon[Order[A]]
+  inline def apply[A](given Order[A]) = summon[Order[A]]
 
   /**
-   * Convert an implicit `Order[B]` to an `Order[A]` using the given
+   * Convert a given `Order[B]` to an `Order[A]` using the given
    * function `f`.
    */
-  def by[@sp A, @sp B](f: A => B) (given ev: Order[B]): Order[A] =
+  def by[@sp A, @sp B](f: A => B)(given ev: Order[B]): Order[A] =
     new Order[A] {
       def compare(x: A, y: A): Int = ev.compare(f(x), f(y))
     }

--- a/src/main/scala/spire/algebra/PartialOrder.scala
+++ b/src/main/scala/spire/algebra/PartialOrder.scala
@@ -78,33 +78,33 @@ trait PartialOrder[@sp A] extends Eq[A] { self =>
 
 abstract class PartialOrderFunctions[P[T] <: PartialOrder[T]] extends EqFunctions[P] {
 
-  def partialCompare[@sp A](x: A, y: A) (given ev: P[A]): Double =
+  def partialCompare[@sp A](x: A, y: A)(given ev: P[A]): Double =
     ev.partialCompare(x, y)
-  def tryCompare[@sp A](x: A, y: A) (given ev: P[A]): Option[Int] =
+  def tryCompare[@sp A](x: A, y: A)(given ev: P[A]): Option[Int] =
     ev.tryCompare(x, y)
 
-  def lteqv[@sp A](x: A, y: A) (given ev: P[A]): Boolean =
+  def lteqv[@sp A](x: A, y: A)(given ev: P[A]): Boolean =
     ev.lteqv(x, y)
-  def lt[@sp A](x: A, y: A) (given ev: P[A]): Boolean =
+  def lt[@sp A](x: A, y: A)(given ev: P[A]): Boolean =
     ev.lt(x, y)
-  def gteqv[@sp A](x: A, y: A) (given ev: P[A]): Boolean =
+  def gteqv[@sp A](x: A, y: A)(given ev: P[A]): Boolean =
     ev.gteqv(x, y)
-  def gt[@sp A](x: A, y: A) (given ev: P[A]): Boolean =
+  def gt[@sp A](x: A, y: A)(given ev: P[A]): Boolean =
     ev.gt(x, y)
 }
 
 object PartialOrder extends PartialOrderFunctions[PartialOrder] {
 
   /**
-   * Access an implicit `PartialOrder[A]`.
+   * Access a given `PartialOrder[A]`.
    */
-  inline def apply[A] (given PartialOrder[A]) = summon[PartialOrder[A]]
+  inline def apply[A](given PartialOrder[A]) = summon[PartialOrder[A]]
 
   /**
-   * Convert an implicit `PartialOrder[B]` to an `PartialOrder[A]` using the given
+   * Convert a given `PartialOrder[B]` to an `PartialOrder[A]` using the given
    * function `f`.
    */
-  def by[@sp A, @sp B](f: A => B) (given ev: PartialOrder[B]): PartialOrder[A] =
+  def by[@sp A, @sp B](f: A => B)(given ev: PartialOrder[B]): PartialOrder[A] =
     new PartialOrder[A] {
       def partialCompare(x: A, y: A): Double = ev.partialCompare(f(x), f(y))
     }

--- a/src/main/scala/spire/instances.scala
+++ b/src/main/scala/spire/instances.scala
@@ -3,4 +3,4 @@ package spire
 import spire.syntax.AllSyntax
 import spire.std.AnyInstances
 
-object implicits extends AnyInstances with AllSyntax
+object instances extends AnyInstances with AllSyntax

--- a/src/main/scala/spire/math/FastComplex.scala
+++ b/src/main/scala/spire/math/FastComplex.scala
@@ -1,9 +1,4 @@
-package spire
-package math
-
-import language.implicitConversions
-
-import java.lang.Math
+package spire.math
 
 object FloatComplex {
   import FastComplex.{encode}
@@ -54,7 +49,7 @@ class FloatComplex(val u: Long) extends AnyVal {
   * Since we're overloading the meaning of Long, all the operations have to be
   * defined on the FastComplex object, meaning the syntax for using this is a
   * bit ugly. To add to the ugly beauty of the whole thing I could imagine
-  * defining implicit operators on Long like +@, -@, *@, /@, etc.
+  * defining operators on Long like +@, -@, *@, /@, etc.
   *
   * You might wonder why it's even worth doing this. The answer is that when
   * you need to allocate an array of e.g. 10-20 million complex numbers, the GC
@@ -119,7 +114,7 @@ object FastComplex {
   // get the complex sign of the complex number
   final def complexSignum(d: Long): Long = {
     val m = Math.abs(d)
-    if (m == 0.0F) zero else divide(d, encode(m, 0.0F))
+    if (m == 0.0F) zero else divide(d, encode(m.toFloat, 0.0F))
   }
 
   // negation
@@ -150,18 +145,16 @@ object FastComplex {
     val abs_re_b = Math.abs(re_b)
     val abs_im_b = Math.abs(im_b)
 
-    if (abs_re_b >= abs_im_b) {
+    if (abs_re_b >= abs_im_b)
       if (abs_re_b == 0.0F) throw new ArithmeticException("/0")
       val ratio = im_b / re_b
       val denom = re_b + im_b * ratio
       encode((re_a + im_a * ratio) / denom, (im_a - re_a * ratio) / denom)
-
-    } else {
+    else
       if (abs_im_b == 0.0F) throw new ArithmeticException("/0")
       val ratio = re_b / im_b
       val denom = re_b * ratio + im_b
       encode((re_a * ratio + im_a) / denom, (im_a * ratio - re_a) / denom)
-    }
   }
 
 }

--- a/src/main/scala/spire/math/Rat.scala
+++ b/src/main/scala/spire/math/Rat.scala
@@ -2,7 +2,7 @@ package spire.math
 
 import spire.algebra._
 
-class Rat(val num: BigInt, val den: BigInt) extends Serializable { lhs =>
+final class Rat(val num: BigInt, val den: BigInt) extends Serializable { lhs =>
 
   override def toString: String =
     if (den == 1) s"$num" else s"$num/$den"
@@ -20,7 +20,7 @@ class Rat(val num: BigInt, val den: BigInt) extends Serializable { lhs =>
   def isOne: Boolean = num == 1 && den == 1
 
   def compare(rhs: Rat): Int =
-    (lhs.num * rhs.den) compare (rhs.num * lhs.den)
+    (lhs.num * rhs.den) `compare` (rhs.num * lhs.den)
 
   def abs(): Rat = Rat(num.abs, den)
 
@@ -37,7 +37,7 @@ class Rat(val num: BigInt, val den: BigInt) extends Serializable { lhs =>
 
   def /~(rhs: Rat) = lhs / rhs
 
-  def %(rhs: Rat) = Rat.Zero
+  def %(rhs: Rat) = Rat.zero
 
   def reciprocal: Rat =
     if (num == 0) throw new ArithmeticException("/0") else Rat(den, num)
@@ -70,10 +70,8 @@ class Rat(val num: BigInt, val den: BigInt) extends Serializable { lhs =>
 
 object Rat {
 
-  val MinusOne: Rat = Rat(-1)
-  val Zero: Rat = Rat(0)
-  val One: Rat = Rat(1)
-  val Two: Rat = Rat(2)
+  val zero: Rat = Rat(0)
+  val one: Rat  = Rat(1)
 
   def apply(n: BigInt): Rat =
     Rat(n, 1)
@@ -83,33 +81,28 @@ object Rat {
     else if (den < 0) apply(-num, -den)
     else if (num == 0) new Rat(0, 1)
     else {
-      val g = num gcd den
+      val g = num `gcd` den
       new Rat(num / g, den / g)
     }
 
-  def unapply(r: Rat): Some[(BigInt, BigInt)] = Some((r.num, r.den))
+  def unapply(r: Rat): (BigInt, BigInt) = (r.num, r.den)
 
-  given ratAlgebra: RatAlgebra = RatAlgebra()
-}
+  given Order[Rat], Field[Rat] {
 
-class RatAlgebra extends Field[Rat] with Order[Rat] with Serializable {
+    def compare(x: Rat, y: Rat): Int = x `compare` y
 
-  def compare(x: Rat, y: Rat): Int = x compare y
+    val zero: Rat = Rat.zero
+    val one: Rat = Rat.one
 
-  val zero: Rat = Rat.Zero
-  val one: Rat = Rat.One
+    def plus(a: Rat, b: Rat): Rat = a + b
+    def negate(a: Rat): Rat = -a
+    def times(a: Rat, b: Rat): Rat = a * b
+    override def reciprocal(a: Rat): Rat = a.reciprocal
+    def div(a: Rat, b: Rat): Rat = a / b
 
-  def plus(a: Rat, b: Rat): Rat = a + b
-  def negate(a: Rat): Rat = -a
-  def times(a: Rat, b: Rat): Rat = a * b
-  override def reciprocal(a: Rat): Rat = a.reciprocal
-  def div(a: Rat, b: Rat): Rat = a / b
+    override def fromInt(n: Int): Rat = Rat(n)
+    override def fromBigInt(n: BigInt): Rat = Rat(n)
 
-  override def fromInt(n: Int): Rat = Rat(n)
-  override def fromBigInt(n: BigInt): Rat = Rat(n)
+  }
 
-  def isWhole(a: Rat): Boolean = a.isWhole
-  def ceil(a: Rat): Rat = a.ceil
-  def floor(a: Rat): Rat = a .floor
-  def round(a: Rat): Rat = a. round
 }

--- a/src/main/scala/spire/math/Sorting.scala
+++ b/src/main/scala/spire/math/Sorting.scala
@@ -1,8 +1,4 @@
-package spire
-package math
-
-
-import scala.language.implicitConversions
+package spire.math
 
 import spire.algebra.Order
 import spire.syntax.order.given
@@ -29,7 +25,7 @@ object InsertionSort extends Sort {
     * @param data the array to be sorted
     * @tparam A a member of the type class `Order`
     */
-  final def sort[@specialized A:Order:ClassTag](data:Array[A]): Unit =
+  final def sort[@specialized A: Order: ClassTag](data: Array[A]): Unit =
     sort(data, 0, data.length)
 
   /**
@@ -41,7 +37,7 @@ object InsertionSort extends Sort {
     * @param end the index of the last element, exclusive, to be sorted
     * @tparam A a member of the type class `Order`
     */
-  final def sort[@specialized A](data:Array[A], start:Int, end:Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
+  final def sort[@specialized A: Order: ClassTag](data: Array[A], start: Int, end: Int): Unit = {
     require(start <= end && start >= 0 && end <= data.length)
     var i = start + 1
     while (i < end) {
@@ -73,7 +69,7 @@ object QuickSort {
     * @param data the array to be sorted
     * @tparam A a member of the type class `Order`
     */
-  final def sort[@specialized A:Order:ClassTag](data:Array[A]): Unit = qsort(data, 0, data.length)
+  final def sort[@specialized A: Order: ClassTag](data: Array[A]): Unit = qsort(data, 0, data.length)
 
   /**
     * Uses quicksort on `data` to sort the entries from the index `start`
@@ -87,7 +83,7 @@ object QuickSort {
     * @param end the index at which to stop sorting (exclusive)
     * @tparam A a member of the type class `Order`
     */
-  final def qsort[@specialized A](data:Array[A], start: Int, end: Int)(implicit o:Order[A], ct:ClassTag[A]): Unit = {
+  final def qsort[@specialized A: Order: ClassTag](data: Array[A], start: Int, end: Int): Unit = {
     require(start >= 0 && end <= data.length)
     if (end - start < limit) {
       InsertionSort.sort(data, start, end)
@@ -112,7 +108,7 @@ object QuickSort {
     * @tparam A a member of the type class Order
     * @return the next pivot value
     */
-  final def partition[@specialized A](data:Array[A], start:Int, end:Int, pivotIndex:Int)(implicit o:Order[A], ct:ClassTag[A]): Int = {
+  final def partition[@specialized A: Order: ClassTag](data: Array[A], start: Int, end: Int, pivotIndex: Int): Int = {
     require(start >= 0 && pivotIndex >= start && end > pivotIndex && end <= data.length)
     val pivotValue = data(pivotIndex)
 
@@ -148,11 +144,11 @@ object QuickSort {
  */
 object Sorting {
   /** Delegates to [[spire.math.QuickSort.sort]] */
-  final def sort[@specialized A:Order:ClassTag](data:Array[A]): Unit = QuickSort.sort(data)
+  final def sort[@specialized A: Order: ClassTag](data: Array[A]): Unit = QuickSort.sort(data)
 
   /** Delegates to [[spire.math.InsertionSort.sort]] */
-  final def insertionSort[@specialized A:Order:ClassTag](data:Array[A]): Unit = InsertionSort.sort(data)
+  final def insertionSort[@specialized A: Order: ClassTag](data: Array[A]): Unit = InsertionSort.sort(data)
 
   /** Delegates to [[spire.math.QuickSort.sort]] */
-  final def quickSort[@specialized A:Order:ClassTag](data:Array[A]): Unit = QuickSort.sort(data)
+  final def quickSort[@specialized A: Order: ClassTag](data: Array[A]): Unit = QuickSort.sort(data)
 }

--- a/src/main/scala/spire/math/UInt.scala
+++ b/src/main/scala/spire/math/UInt.scala
@@ -1,15 +1,31 @@
-package spire
-package math
-
-import language.implicitConversions
+package spire.math
 
 import spire.algebra.{CRig, Order}
 
 object UInt {
 
-  implicit final val algebra: Order[UInt] with CRig[UInt] = UIntAlgebra()
+  given Order[UInt], CRig[UInt] {
 
-  final def apply(n: Long): UInt = UInt(summon[Numeric[Long]].toLong(n))
+    // Order
+
+    def compare(x: UInt, y: UInt): Int = if (x < y) -1 else if (x > y) 1 else 0
+    override def eqv(x:UInt, y:UInt): Boolean = x == y
+    override def neqv(x:UInt, y:UInt): Boolean = x != y
+    override def gt(x: UInt, y: UInt): Boolean = x > y
+    override def gteqv(x: UInt, y: UInt): Boolean = x >= y
+    override def lt(x: UInt, y: UInt): Boolean = x < y
+    override def lteqv(x: UInt, y: UInt): Boolean = x <= y
+
+    // CRig
+
+    def one: UInt = UInt(1)
+    def plus(a:UInt, b:UInt): UInt = a + b
+    override def times(a:UInt, b:UInt): UInt = a * b
+    def zero: UInt = UInt(0)
+
+  }
+
+  private inline def fromLong(l: Long): UInt = UInt(l.toInt)
 
   @inline final val MinValue: UInt = UInt(0)
   @inline final val MaxValue: UInt = UInt(-1)
@@ -49,8 +65,8 @@ class UInt(val signed: Int) extends AnyVal {
   def + (that: UInt): UInt = UInt(this.signed + that.signed)
   def - (that: UInt): UInt = UInt(this.signed - that.signed)
   def * (that: UInt): UInt = UInt(this.signed * that.signed)
-  def / (that: UInt): UInt = UInt(this.toLong / that.toLong)
-  def % (that: UInt): UInt = UInt(this.toLong % that.toLong)
+  def / (that: UInt): UInt = UInt.fromLong(this.toLong / that.toLong)
+  def % (that: UInt): UInt = UInt.fromLong(this.toLong % that.toLong)
 
   def unary_~ : UInt = UInt(~this.signed)
 
@@ -60,25 +76,4 @@ class UInt(val signed: Int) extends AnyVal {
   def & (that: UInt): UInt = UInt(this.signed & that.signed)
   def | (that: UInt): UInt = UInt(this.signed | that.signed)
   def ^ (that: UInt): UInt = UInt(this.signed ^ that.signed)
-}
-
-final class UIntAlgebra extends Order[UInt] with CRig[UInt] {
-
-  // Order
-
-  def compare(x: UInt, y: UInt): Int = if (x < y) -1 else if (x > y) 1 else 0
-  override def eqv(x:UInt, y:UInt): Boolean = x == y
-  override def neqv(x:UInt, y:UInt): Boolean = x != y
-  override def gt(x: UInt, y: UInt): Boolean = x > y
-  override def gteqv(x: UInt, y: UInt): Boolean = x >= y
-  override def lt(x: UInt, y: UInt): Boolean = x < y
-  override def lteqv(x: UInt, y: UInt): Boolean = x <= y
-
-  // CRig
-
-  def one: UInt = UInt(1)
-  def plus(a:UInt, b:UInt): UInt = a + b
-  override def times(a:UInt, b:UInt): UInt = a * b
-  def zero: UInt = UInt(0)
-
 }

--- a/src/main/scala/spire/math/ULong.scala
+++ b/src/main/scala/spire/math/ULong.scala
@@ -1,7 +1,4 @@
-package spire
-package math
-
-import language.implicitConversions
+package spire.math
 
 import spire.algebra.{CRig, Order}
 import java.lang.Math
@@ -9,7 +6,26 @@ import scala.annotation.tailrec
 
 object ULong {
 
-  implicit val algebra: Order[ULong] with CRig[ULong] = new ULongAlgebra
+  given Order[ULong], CRig[ULong] {
+
+    // Order
+
+    def compare(x: ULong, y: ULong): Int = if (x < y) -1 else if (x > y) 1 else 0
+    override def eqv(x:ULong, y:ULong): Boolean = x == y
+    override def neqv(x:ULong, y:ULong): Boolean = x != y
+    override def gt(x: ULong, y: ULong): Boolean = x > y
+    override def gteqv(x: ULong, y: ULong): Boolean = x >= y
+    override def lt(x: ULong, y: ULong): Boolean = x < y
+    override def lteqv(x: ULong, y: ULong): Boolean = x <= y
+
+    // CRig
+
+    def one: ULong = ULong(1)
+    def plus(a:ULong, b:ULong): ULong = a + b
+    override def times(a:ULong, b:ULong): ULong = a * b
+    def zero: ULong = ULong(0)
+
+  }
 
   inline def apply(n: Long): ULong = new ULong(n)
 
@@ -103,7 +119,7 @@ class ULong(val signed: Long) extends AnyVal {
     if (d == 0) {
       throw new java.lang.ArithmeticException("/ by zero")
     } else if (d < 0) {
-      ULong(if (n >= 0 || n < d) 0 else 1)
+      ULong(if (n >= 0 || n < d) 0L else 1L)
     } else if (n >= 0) {
       ULong(n / d)
     } else {
@@ -135,24 +151,4 @@ class ULong(val signed: Long) extends AnyVal {
   final def ** (that: ULong): ULong = ULong.pow(1L, this.signed, that.signed)
 
   final def gcd (that: ULong): ULong = ULong.gcd(this, that)
-}
-
-final class ULongAlgebra extends Order[ULong] with CRig[ULong] {
-
-  // Order
-
-  def compare(x: ULong, y: ULong): Int = if (x < y) -1 else if (x > y) 1 else 0
-  override def eqv(x:ULong, y:ULong): Boolean = x == y
-  override def neqv(x:ULong, y:ULong): Boolean = x != y
-  override def gt(x: ULong, y: ULong): Boolean = x > y
-  override def gteqv(x: ULong, y: ULong): Boolean = x >= y
-  override def lt(x: ULong, y: ULong): Boolean = x < y
-  override def lteqv(x: ULong, y: ULong): Boolean = x <= y
-
-  // CRig
-
-  def one: ULong = ULong(1)
-  def plus(a:ULong, b:ULong): ULong = a + b
-  override def times(a:ULong, b:ULong): ULong = a * b
-  def zero: ULong = ULong(0)
 }

--- a/src/main/scala/spire/std/any.scala
+++ b/src/main/scala/spire/std/any.scala
@@ -1,8 +1,8 @@
 package spire.std
 
 trait AnyInstances extends IntInstances
-    with LongInstances
-    with FloatInstances
-    with DoubleInstances
-    with BigIntegerInstances
-    with BigDecimalInstances
+  with LongInstances
+  with FloatInstances
+  with DoubleInstances
+  with BigIntegerInstances
+  with BigDecimalInstances

--- a/src/main/scala/spire/std/bigDecimal.scala
+++ b/src/main/scala/spire/std/bigDecimal.scala
@@ -4,39 +4,39 @@ import java.math.MathContext
 
 import spire.algebra.{Field, Order}
 
-class BigDecimalAlgebra extends Order[BigDecimal] with Field[BigDecimal] {
-
-  // Order
-
-  override def eqv(x: BigDecimal, y: BigDecimal): Boolean = x == y
-  override def neqv(x: BigDecimal, y: BigDecimal): Boolean = x != y
-  override def gt(x: BigDecimal, y: BigDecimal): Boolean = x > y
-  override def gteqv(x: BigDecimal, y: BigDecimal): Boolean = x >= y
-  override def lt(x: BigDecimal, y: BigDecimal): Boolean = x < y
-  override def lteqv(x: BigDecimal, y: BigDecimal): Boolean = x <= y
-
-  // Scala compareTo has no guarantee to return only -1, 0 or 1 as per Spire compare contract,
-  // so we call Java's compareTo which does
-  def compare(x: BigDecimal, y: BigDecimal): Int = x.bigDecimal.compareTo(y.bigDecimal)
-
-  // Field
-
-  override def minus(a: BigDecimal, b: BigDecimal): BigDecimal = a - b
-  def negate(a: BigDecimal): BigDecimal = -a
-  val one: BigDecimal = BigDecimal(1.0)
-  def plus(a: BigDecimal, b: BigDecimal): BigDecimal = a + b
-  override def times(a: BigDecimal, b: BigDecimal): BigDecimal = a * b
-  val zero: BigDecimal = BigDecimal(0.0)
-
-  override def fromInt(n: Int): BigDecimal = BigDecimal(n)
-  override def fromBigInt(n: BigInt): BigDecimal = BigDecimal(n)
-  override def fromDouble(n: Double): BigDecimal = BigDecimal(n)
-  override def fromBigDecimal(n: BigDecimal): BigDecimal = n
-
-  def div(a: BigDecimal, b: BigDecimal): BigDecimal = a / b
-
-}
-
 trait BigDecimalInstances {
-  implicit final val BigDecimalAlgebra: Order[BigDecimal] & Field[BigDecimal] = new BigDecimalAlgebra
+
+  given Order[BigDecimal], Field[BigDecimal] {
+
+    // Order
+
+    override def eqv(x: BigDecimal, y: BigDecimal): Boolean = x == y
+    override def neqv(x: BigDecimal, y: BigDecimal): Boolean = x != y
+    override def gt(x: BigDecimal, y: BigDecimal): Boolean = x > y
+    override def gteqv(x: BigDecimal, y: BigDecimal): Boolean = x >= y
+    override def lt(x: BigDecimal, y: BigDecimal): Boolean = x < y
+    override def lteqv(x: BigDecimal, y: BigDecimal): Boolean = x <= y
+
+    // Scala compareTo has no guarantee to return only -1, 0 or 1 as per Spire compare contract,
+    // so we call Java's compareTo which does
+    def compare(x: BigDecimal, y: BigDecimal): Int = x.bigDecimal.compareTo(y.bigDecimal)
+
+    // Field
+
+    override def minus(a: BigDecimal, b: BigDecimal): BigDecimal = a - b
+    def negate(a: BigDecimal): BigDecimal = -a
+    val one: BigDecimal = BigDecimal(1.0)
+    def plus(a: BigDecimal, b: BigDecimal): BigDecimal = a + b
+    override def times(a: BigDecimal, b: BigDecimal): BigDecimal = a * b
+    val zero: BigDecimal = BigDecimal(0.0)
+
+    override def fromInt(n: Int): BigDecimal = BigDecimal(n)
+    override def fromBigInt(n: BigInt): BigDecimal = BigDecimal(n)
+    override def fromDouble(n: Double): BigDecimal = BigDecimal(n)
+    override def fromBigDecimal(n: BigDecimal): BigDecimal = n
+
+    def div(a: BigDecimal, b: BigDecimal): BigDecimal = a / b
+
+  }
+
 }

--- a/src/main/scala/spire/std/bigInteger.scala
+++ b/src/main/scala/spire/std/bigInteger.scala
@@ -1,36 +1,35 @@
-package spire
-package std
-
-import language.implicitConversions
+package spire.std
 
 import java.math.BigInteger
 
 import spire.algebra.{CRing, Eq, Order}
 
-final class BigIntegerAlgebra extends Order[BigInteger] with CRing[BigInteger] {
-  // Order
-
-  def compare(x: BigInteger, y: BigInteger): Int = x compareTo y
-  override def eqv(x:BigInteger, y:BigInteger): Boolean = x equals y
-  override def neqv(x:BigInteger, y:BigInteger): Boolean = !(x equals y)
-  override def gt(x: BigInteger, y: BigInteger): Boolean = (x compareTo y) > 0
-  override def gteqv(x: BigInteger, y: BigInteger): Boolean = (x compareTo y) >= 0
-  override def lt(x: BigInteger, y: BigInteger): Boolean = (x compareTo y) < 0
-  override def lteqv(x: BigInteger, y: BigInteger): Boolean = (x compareTo y) <= 0
-
-  // CRing
-
-  override def minus(a: BigInteger, b: BigInteger): BigInteger = a subtract b
-  def negate(a: BigInteger): BigInteger = a.negate
-  def one: BigInteger = BigInteger.ONE
-  def plus(a: BigInteger, b: BigInteger): BigInteger = a add b
-  override def times(a: BigInteger, b: BigInteger): BigInteger = a multiply b
-  def zero: BigInteger = BigInteger.ZERO
-
-  override def fromInt(n: Int): BigInteger = BigInteger.valueOf(n)
-  override def fromBigInt(n: BigInt): BigInteger = n.underlying
-}
-
 trait BigIntegerInstances {
-  implicit final val BigIntegerAlgebra: BigIntegerAlgebra = new BigIntegerAlgebra
+
+  given Order[BigInteger], CRing[BigInteger] {
+
+    // Order
+
+    def compare(x: BigInteger, y: BigInteger): Int = x compareTo y
+    override def eqv(x:BigInteger, y:BigInteger): Boolean = x equals y
+    override def neqv(x:BigInteger, y:BigInteger): Boolean = !(x equals y)
+    override def gt(x: BigInteger, y: BigInteger): Boolean = (x compareTo y) > 0
+    override def gteqv(x: BigInteger, y: BigInteger): Boolean = (x compareTo y) >= 0
+    override def lt(x: BigInteger, y: BigInteger): Boolean = (x compareTo y) < 0
+    override def lteqv(x: BigInteger, y: BigInteger): Boolean = (x compareTo y) <= 0
+
+    // CRing
+
+    override def minus(a: BigInteger, b: BigInteger): BigInteger = a subtract b
+    def negate(a: BigInteger): BigInteger = a.negate
+    def one: BigInteger = BigInteger.ONE
+    def plus(a: BigInteger, b: BigInteger): BigInteger = a add b
+    override def times(a: BigInteger, b: BigInteger): BigInteger = a multiply b
+    def zero: BigInteger = BigInteger.ZERO
+
+    override def fromInt(n: Int): BigInteger = BigInteger.valueOf(n.toLong)
+    override def fromBigInt(n: BigInt): BigInteger = n.underlying
+
+  }
+
 }

--- a/src/main/scala/spire/std/double.scala
+++ b/src/main/scala/spire/std/double.scala
@@ -1,37 +1,33 @@
-package spire
-package std
-
-import language.implicitConversions
+package spire.std
 
 import spire.algebra.{Field, Order}
-import java.lang.Math
-
-final class DoubleAlgebra extends Order[Double] with Field[Double] {
-
-  // Field
-  override def minus(a:Double, b:Double): Double = a - b
-  def negate(a:Double): Double = -a
-  def one: Double = 1.0
-  def plus(a:Double, b:Double): Double = a + b
-  override def times(a:Double, b:Double): Double = a * b
-  def zero: Double = 0.0
-
-  override def fromInt(n: Int): Double = n
-  override def fromDouble(n: Double): Double = n
-
-  def div(a:Double, b:Double): Double = a / b
-
-  // Order
-  override def eqv(x:Double, y:Double): Boolean = x == y
-  override def neqv(x:Double, y:Double): Boolean = x != y
-  override def gt(x: Double, y: Double): Boolean = x > y
-  override def gteqv(x: Double, y: Double): Boolean = x >= y
-  override def lt(x: Double, y: Double): Boolean = x < y
-  override def lteqv(x: Double, y: Double): Boolean = x <= y
-  def compare(x: Double, y: Double): Int = java.lang.Double.compare(x, y)
-
-}
 
 trait DoubleInstances {
-  implicit final val DoubleAlgebra: DoubleAlgebra = new DoubleAlgebra
+
+  given Order[Double], Field[Double] {
+
+    // Field
+    override def minus(a:Double, b:Double): Double = a - b
+    def negate(a:Double): Double = -a
+    def one: Double = 1.0
+    def plus(a:Double, b:Double): Double = a + b
+    override def times(a:Double, b:Double): Double = a * b
+    def zero: Double = 0.0
+
+    override def fromInt(n: Int): Double = n.toDouble
+    override def fromDouble(n: Double): Double = n
+
+    def div(a:Double, b:Double): Double = a / b
+
+    // Order
+    override def eqv(x:Double, y:Double): Boolean = x == y
+    override def neqv(x:Double, y:Double): Boolean = x != y
+    override def gt(x: Double, y: Double): Boolean = x > y
+    override def gteqv(x: Double, y: Double): Boolean = x >= y
+    override def lt(x: Double, y: Double): Boolean = x < y
+    override def lteqv(x: Double, y: Double): Boolean = x <= y
+    def compare(x: Double, y: Double): Int = java.lang.Double.compare(x, y)
+
+  }
+
 }

--- a/src/main/scala/spire/std/float.scala
+++ b/src/main/scala/spire/std/float.scala
@@ -1,38 +1,34 @@
-package spire
-package std
-
-import language.implicitConversions
+package spire.std
 
 import spire.algebra.{Field, Order}
 
-final class FloatAlgebra extends Order[Float] with Field[Float] {
-
-  // Order
-
-  def compare(x: Float, y: Float): Int = java.lang.Float.compare(x, y)
-  override def eqv(x:Float, y:Float): Boolean = x == y
-  override def neqv(x:Float, y:Float): Boolean = x != y
-  override def gt(x: Float, y: Float): Boolean = x > y
-  override def gteqv(x: Float, y: Float): Boolean = x >= y
-  override def lt(x: Float, y: Float): Boolean = x < y
-  override def lteqv(x: Float, y: Float): Boolean = x <= y
-
-  // Field
-  override def minus(a:Float, b:Float): Float = a - b
-  def negate(a:Float): Float = -a
-  def one: Float = 1.0F
-  def plus(a:Float, b:Float): Float = a + b
-  override def times(a:Float, b:Float): Float = a * b
-  def zero: Float = 0.0F
-
-  override def fromInt(n: Int): Float = n
-  override def fromDouble(n: Double): Float = n.toFloat
-
-  def div(a:Float, b:Float): Float = a / b
-
-}
-
-
 trait FloatInstances {
-  implicit final val FloatAlgebra: FloatAlgebra = new FloatAlgebra
+
+  given Order[Float], Field[Float] {
+
+    // Order
+
+    def compare(x: Float, y: Float): Int = java.lang.Float.compare(x, y)
+    override def eqv(x:Float, y:Float): Boolean = x == y
+    override def neqv(x:Float, y:Float): Boolean = x != y
+    override def gt(x: Float, y: Float): Boolean = x > y
+    override def gteqv(x: Float, y: Float): Boolean = x >= y
+    override def lt(x: Float, y: Float): Boolean = x < y
+    override def lteqv(x: Float, y: Float): Boolean = x <= y
+
+    // Field
+    override def minus(a:Float, b:Float): Float = a - b
+    def negate(a:Float): Float = -a
+    def one: Float = 1.0F
+    def plus(a:Float, b:Float): Float = a + b
+    override def times(a:Float, b:Float): Float = a * b
+    def zero: Float = 0.0F
+
+    override def fromInt(n: Int): Float = n.toFloat
+    override def fromDouble(n: Double): Float = n.toFloat
+
+    def div(a:Float, b:Float): Float = a / b
+
+  }
+
 }

--- a/src/main/scala/spire/std/int.scala
+++ b/src/main/scala/spire/std/int.scala
@@ -1,33 +1,31 @@
-package spire
-package std
+package spire.std
 
 import spire.algebra.{CRing, Order}
 
-final class IntAlgebra extends Order[Int] with CRing[Int] {
-
-  // Order
-
-  def compare(x: Int, y: Int): Int = if (x < y) -1 else if (x == y) 0 else 1
-  override def eqv(x: Int, y: Int): Boolean = x == y
-  override def neqv(x: Int, y: Int): Boolean = x != y
-  override def gt(x: Int, y: Int): Boolean = x > y
-  override def gteqv(x: Int, y: Int): Boolean = x >= y
-  override def lt(x: Int, y: Int): Boolean = x < y
-  override def lteqv(x: Int, y: Int): Boolean = x <= y
-
-  // CRing
-  override def minus(a:Int, b:Int): Int = a - b
-  def negate(a:Int): Int = -a
-  def one: Int = 1
-  def plus(a:Int, b:Int): Int = a + b
-  override def times(a:Int, b:Int): Int = a * b
-  def zero: Int = 0
-
-  override def fromInt(n: Int): Int = n
-
-}
-
-
 trait IntInstances {
-  implicit final val IntAlgebra: Order[Int] with CRing[Int] = new IntAlgebra
+
+  given Order[Int], CRing[Int] {
+
+    // Order
+
+    def compare(x: Int, y: Int): Int = if (x < y) -1 else if (x == y) 0 else 1
+    override def eqv(x: Int, y: Int): Boolean = x == y
+    override def neqv(x: Int, y: Int): Boolean = x != y
+    override def gt(x: Int, y: Int): Boolean = x > y
+    override def gteqv(x: Int, y: Int): Boolean = x >= y
+    override def lt(x: Int, y: Int): Boolean = x < y
+    override def lteqv(x: Int, y: Int): Boolean = x <= y
+
+    // CRing
+
+    override def minus(a:Int, b:Int): Int = a - b
+    def negate(a:Int): Int = -a
+    def one: Int = 1
+    def plus(a:Int, b:Int): Int = a + b
+    override def times(a:Int, b:Int): Int = a * b
+    def zero: Int = 0
+    override def fromInt(n: Int): Int = n
+
+  }
+
 }

--- a/src/main/scala/spire/std/long.scala
+++ b/src/main/scala/spire/std/long.scala
@@ -1,36 +1,31 @@
-package spire
-package std
-
-import language.implicitConversions
+package spire.std
 
 import spire.algebra.{Order, CRing}
-import java.lang.Math
-
-final class LongAlgebra extends Order[Long] with CRing[Long] {
-
-  // CRing
-
-  override def minus(a:Long, b:Long): Long = a - b
-  def negate(a:Long): Long = -a
-  def one: Long = 1L
-  def plus(a:Long, b:Long): Long = a + b
-  override def times(a:Long, b:Long): Long = a * b
-  def zero: Long = 0L
-
-  override def fromInt(n: Int): Long = n
-
-  // Order
-
-  override def eqv(x:Long, y:Long): Boolean = x == y
-  override def neqv(x:Long, y:Long): Boolean = x != y
-  override def gt(x: Long, y: Long): Boolean = x > y
-  override def gteqv(x: Long, y: Long): Boolean = x >= y
-  override def lt(x: Long, y: Long): Boolean = x < y
-  override def lteqv(x: Long, y: Long): Boolean = x <= y
-  def compare(x: Long, y: Long): Int = if (x < y) -1 else if (x == y) 0 else 1
-
-}
 
 trait LongInstances {
-  implicit final val LongAlgebra: Order[Long] with CRing[Long] = new LongAlgebra
+
+    given Order[Long], CRing[Long] {
+
+    // CRing
+
+    override def minus(a:Long, b:Long): Long = a - b
+    def negate(a:Long): Long = -a
+    def one: Long = 1L
+    def plus(a:Long, b:Long): Long = a + b
+    override def times(a:Long, b:Long): Long = a * b
+    def zero: Long = 0L
+    override def fromInt(n: Int): Long = n.toLong
+
+    // Order
+
+    override def eqv(x:Long, y:Long): Boolean = x == y
+    override def neqv(x:Long, y:Long): Boolean = x != y
+    override def gt(x: Long, y: Long): Boolean = x > y
+    override def gteqv(x: Long, y: Long): Boolean = x >= y
+    override def lt(x: Long, y: Long): Boolean = x < y
+    override def lteqv(x: Long, y: Long): Boolean = x <= y
+    def compare(x: Long, y: Long): Int = if (x < y) -1 else if (x == y) 0 else 1
+
+  }
+
 }

--- a/src/main/scala/spire/syntax/Literals.scala
+++ b/src/main/scala/spire/syntax/Literals.scala
@@ -1,5 +1,4 @@
-package spire
-package syntax
+package spire.syntax
 
 import spire.algebra.{Field, CRing}
 
@@ -7,72 +6,52 @@ import scala.quoted._
 import scala.quoted.matching._
 import scala.util.FromDigits
 
-object primitives {
+object literals {
 
-  inline def (n: => Int) as [A] (given A: CRing[A]): A = inline n match
-    case 0 => A.zero
-    case 1 => A.one
-    case n => A.fromInt(n)
-
-  inline def (n: => Double) as [A] (given A: Field[A]): A = inline n match
-    case 0 => A.zero
-    case 1 => A.one
-    case n => A.fromDouble(n)
-
-  private inline def ringFromBigInt[A](digits: String, radix: Int)(given A: CRing[A]) =
-    A.fromBigInt(summon[FromDigits[BigInt]].fromDigits(digits, radix))
-
-  private inline def fieldFromBigDecimal[A](digits: String)(given A: Field[A]) =
-    A.fromBigDecimal(summon[FromDigits[BigDecimal]].fromDigits(digits))
-
-  class RingLiteral[A](given CRing[A]) extends FromDigits.WithRadix[A]
-    def fromDigits(digits: String, radix: Int): A = ringFromBigInt(digits, radix)
-
-  class FieldLiteral[A](given Field[A]) extends FromDigits.Floating[A]
-    def fromDigits(digits: String): A = fieldFromBigDecimal(digits)
-
-  given [A](given ev: CRing[A]): RingLiteral[A]
+  given [A](given ev: CRing[A]): RadixLiteral[A]
+    override inline def fromDigits(digits: String): A =
+      ${ fromRingImpl('digits, Expr(10), 'ev) }
     override inline def fromDigits(digits: String, radix: Int): A =
       ${ fromRingImpl('digits, 'radix, 'ev) }
 
-  given [A](given ev: Field[A]): FieldLiteral[A]
+  given [A](given ev: Field[A]): FloatingLiteral[A]
     override inline def fromDigits(digits: String): A =
       ${ fromFieldImpl('digits, 'ev) }
 
-  def fromRingImpl[A: Type](digits: Expr[String], radix: Expr[Int], ring: Expr[CRing[A]])(given qctx: QuoteContext): Expr[A] =
-    (digits, radix) match
-    case (Const(ds), Const(r)) =>
-      try
-        FromDigits.intFromDigits(ds, r) match
-          case 0 => '{ $ring.zero }
-          case 1 => '{ $ring.one }
-          case n => '{ $ring.fromInt(${Expr(n)}) }
-      catch
-        case e: (FromDigits.NumberTooLarge | FromDigits.MalformedNumber) =>
-          '{ ringFromBigInt($digits, $radix)(given $ring) }
-    case _ => '{ ringFromBigInt($digits, $radix)(given $ring) }
+  private def fromRingImpl[A: Type](digits: Expr[String], radix: Expr[Int], A: Expr[CRing[A]])(given QuoteContext): Expr[A] =
+    digits -> radix match
+    case Const(ds) -> Const(r) => fromBigIntImpl(BigInt(ds, r), A)
+    case _                     => '{ $A.fromBigInt(BigInt($digits, $radix)) }
 
-  def fromFieldImpl[A: Type](digits: Expr[String], field: Expr[Field[A]])(given qctx: QuoteContext): Expr[A] =
+  private def fromFieldImpl[A: Type](digits: Expr[String], A: Expr[Field[A]])(given QuoteContext): Expr[A] =
     digits match
     case Const(ds) =>
-      try
-        FromDigits.intFromDigits(ds) match
-          case 0 => '{ $field.zero }
-          case 1 => '{ $field.one }
-          case n => '{ $field.fromInt(${Expr(n)}) }
-      catch
-        case e: (FromDigits.NumberTooLarge | FromDigits.MalformedNumber) =>
-          if """.*[.eE].*""".r.matches(ds) then
-            if BigDecimal(ds).isDecimalDouble then
-              FromDigits.doubleFromDigits(ds) match
-                case 0.0 => '{ $field.zero }
-                case 1.0 => '{ $field.one }
-                case n   => '{ $field.fromDouble(${Expr(n)}) }
-            else
-              '{ fieldFromBigDecimal($digits)(given $field) }
-          else
-            '{ ringFromBigInt($digits, ${Expr(10)})(given $field) }
+      if floating.matches(ds) then
+        val bigdec = BigDecimal(ds)
+        if bigdec.isDecimalDouble || bigdec.isBinaryDouble || bigdec.isExactDouble then bigdec.toDouble match
+          case 0.0 => '{ $A.zero                     }
+          case 1.0 => '{ $A.one                      }
+          case n   => '{ $A.fromDouble(${ Expr(n) }) }
+        else
+          '{ $A.fromBigDecimal(${ Expr(bigdec) }) }
+      else
+        fromBigIntImpl(BigInt(ds), A)
 
-    case _ => '{ fieldFromBigDecimal($digits)(given $field) }
+    case _ => '{ $A.fromBigDecimal(BigDecimal($digits)) }
+
+  private def fromBigIntImpl[A: Type](bigint: BigInt, A: Expr[CRing[A]])(given QuoteContext): Expr[A] =
+    if bigint.isValidInt then bigint.toInt match
+      case 0 => '{ $A.zero                  }
+      case 1 => '{ $A.one                   }
+      case n => '{ $A.fromInt(${ Expr(n) }) }
+    else '{ $A.fromBigInt(${ Expr(bigint) }) }
+
+  private val floating = """.*[.eE].*""".r
+
+  class RadixLiteral[A](given A: CRing[A]) extends FromDigits.WithRadix[A]
+    def fromDigits(digits: String, radix: Int): A = A.fromBigInt(BigInt(digits, radix))
+
+  class FloatingLiteral[A](given A: Field[A]) extends FromDigits.Floating[A]
+    def fromDigits(digits: String): A = A.fromBigDecimal(BigDecimal(digits))
 
 }

--- a/src/main/scala/spire/syntax/Syntax.scala
+++ b/src/main/scala/spire/syntax/Syntax.scala
@@ -4,14 +4,14 @@ package syntax
 import spire.algebra._
 
 trait EqSyntax {
-  given eqSyntax[A:Eq]: {
-    inline def (lhs:A) === [B] (rhs: B) (given ev1: B =:= A): Boolean = Eq[A].eqv(lhs, ev1(rhs))
-    inline def (lhs:A) =!= [B] (rhs: B) (given ev1: B =:= A): Boolean = Eq[A].neqv(lhs, ev1(rhs))
+  given eqSyntax[A: Eq]: {
+    inline def (lhs: A) === [B] (rhs: B)(given ev1: B =:= A): Boolean = Eq[A].eqv(lhs, ev1(rhs))
+    inline def (lhs: A) =!= [B] (rhs: B)(given ev1: B =:= A): Boolean = Eq[A].neqv(lhs, ev1(rhs))
   }
 }
 
 trait PartialOrderSyntax extends EqSyntax {
-  given partialorderSyntax[A:PartialOrder]: {
+  given partialorderSyntax[A: PartialOrder]: {
     inline def (lhs: A) >  (rhs: A): Boolean = PartialOrder[A].gt(lhs, rhs)
     inline def (lhs: A) >= (rhs: A): Boolean = PartialOrder[A].gteqv(lhs, rhs)
     inline def (lhs: A) <  (rhs: A): Boolean = PartialOrder[A].lt(lhs, rhs)
@@ -23,29 +23,29 @@ trait PartialOrderSyntax extends EqSyntax {
 }
 
 trait OrderSyntax extends PartialOrderSyntax {
-  given orderSyntax[A:Order]: {
+  given orderSyntax[A: Order]: {
     inline def (lhs: A) compare(rhs: A): Int = Order[A].compare(lhs, rhs)
   }
 }
 
 trait CRigSyntax {
-  given crigSyntax[A:CRig]: {
-    inline def (lhs: A) +      (rhs: A)   : A       = CRig[A].plus(lhs, rhs)
+  given crigSyntax[A: CRig]: {
+    inline def (lhs: A) +      (rhs: A)     : A       = CRig[A].plus(lhs, rhs)
     inline def (lhs: A) isZero (given Eq[A]): Boolean = CRig[A].isZero(lhs)
-    inline def (lhs: A) *      (rhs: A)   : A       = CRig[A].times(lhs, rhs)
+    inline def (lhs: A) *      (rhs: A)     : A       = CRig[A].times(lhs, rhs)
     inline def (lhs: A) isOne  (given Eq[A]): Boolean = CRig[A].isOne(lhs)
   }
 }
 
 trait CRingSyntax extends CRigSyntax {
-  given cringSyntax[A:CRing]: {
+  given cringSyntax[A: CRing]: {
     inline def (lhs: A) unary_-   : A = CRing[A].negate(lhs)
     inline def (lhs: A) - (rhs: A): A = CRing[A].minus(lhs, rhs)
   }
 }
 
 trait FieldSyntax extends CRingSyntax {
-  given fieldSyntax[A:Field]: {
+  given fieldSyntax[A: Field]: {
     inline def (lhs: A) reciprocal(): A = Field[A].reciprocal(lhs)
     inline def (lhs: A) / (rhs: A)  : A = Field[A].div(lhs, rhs)
   }

--- a/src/main/scala/spire/syntax/macros/cforMacros.scala
+++ b/src/main/scala/spire/syntax/macros/cforMacros.scala
@@ -1,9 +1,6 @@
 package spire.syntax.macros
 
-import language.implicitConversions
-
 import quoted._
-import quoted.autolift.given
 import quoted.matching._
 import collection.immutable.NumericRange
 
@@ -17,8 +14,7 @@ inline def cforInline[R](init: => R, test: => R => Boolean, next: => R => R, bod
   }
 }
 
-def cforRangeMacroGen[R <: RangeLike : Type](r: Expr[R], body: Expr[RangeElem[R] => Unit])
-    (given qctx: QuoteContext): Expr[Unit] = {
+def cforRangeMacroGen[R <: RangeLike : Type](r: Expr[R], body: Expr[RangeElem[R] => Unit])(given qctx: QuoteContext): Expr[Unit] = {
   import qctx._
   import tasty.{error => _,_}
 
@@ -31,7 +27,7 @@ def cforRangeMacroGen[R <: RangeLike : Type](r: Expr[R], body: Expr[RangeElem[R]
   }
 }
 
-def cforRangeMacroLong(r: Expr[NumericRange[Long]], body: Expr[Long => Unit]) (given qctx: QuoteContext): Expr[Unit] = {
+def cforRangeMacroLong(r: Expr[NumericRange[Long]], body: Expr[Long => Unit])(given qctx: QuoteContext): Expr[Unit] = {
   import qctx._
 
   def strideUpUntil(fromExpr: Expr[Long], untilExpr: Expr[Long], stride: Expr[Long]): Expr[Unit] = '{
@@ -71,13 +67,13 @@ def cforRangeMacroLong(r: Expr[NumericRange[Long]], body: Expr[Long => Unit]) (g
   }
 
   r match {
-    case '{ ($i: Long) until $j } => strideUpUntil(i,j,1L)
-    case '{ ($i: Long) to $j }    => strideUpTo(i,j,1L)
+    case '{ ($i: Long) until $j } => strideUpUntil(i,j,Expr(1L))
+    case '{ ($i: Long) to $j }    => strideUpTo(i,j,Expr(1L))
 
     case '{ ($i: Long) until $j by $step } =>
       step match {
-        case Const(k) if k  > 0 => strideUpUntil(i,j,k)
-        case Const(k) if k  < 0 => strideDownUntil(i,j,-k)
+        case Const(k) if k  > 0 => strideUpUntil(i,j,Expr(k))
+        case Const(k) if k  < 0 => strideDownUntil(i,j,Expr(-k))
         case Const(k) if k == 0 => error("zero stride", step); '{}
 
         case _ =>
@@ -87,8 +83,8 @@ def cforRangeMacroLong(r: Expr[NumericRange[Long]], body: Expr[Long => Unit]) (g
 
     case '{ ($i: Long) to $j by $step } =>
       step match {
-        case Const(k) if k  > 0 => strideUpTo(i,j,k)
-        case Const(k) if k  < 0 => strideDownTo(i,j,-k)
+        case Const(k) if k  > 0 => strideUpTo(i,j,Expr(k))
+        case Const(k) if k  < 0 => strideDownTo(i,j,Expr(-k))
         case Const(k) if k == 0 => error("zero stride", step); '{}
 
         case _ =>
@@ -102,9 +98,9 @@ def cforRangeMacroLong(r: Expr[NumericRange[Long]], body: Expr[Long => Unit]) (g
   }
 }
 
-def cforRangeMacro(r: Expr[Range], body: Expr[Int => Unit]) (given qctx: QuoteContext): Expr[Unit] = {
+def cforRangeMacro(r: Expr[Range], body: Expr[Int => Unit])(given qctx: QuoteContext): Expr[Unit] = {
   import qctx._
-  
+
   def strideUpUntil(fromExpr: Expr[Int], untilExpr: Expr[Int], stride: Expr[Int]): Expr[Unit] = '{
     var index = $fromExpr
     val limit = $untilExpr
@@ -142,13 +138,13 @@ def cforRangeMacro(r: Expr[Range], body: Expr[Int => Unit]) (given qctx: QuoteCo
   }
 
   r match {
-    case '{ ($i: Int) until $j } => strideUpUntil(i,j,1)
-    case '{ ($i: Int) to $j }    => strideUpTo(i,j,1)
+    case '{ ($i: Int) until $j } => strideUpUntil(i,j,Expr(1))
+    case '{ ($i: Int) to $j }    => strideUpTo(i,j,Expr(1))
 
     case '{ ($i: Int) until $j by $step } =>
       step match {
-        case Const(k) if k  > 0 => strideUpUntil(i,j,k)
-        case Const(k) if k  < 0 => strideDownUntil(i,j,-k)
+        case Const(k) if k  > 0 => strideUpUntil(i,j,Expr(k))
+        case Const(k) if k  < 0 => strideDownUntil(i,j,Expr(-k))
         case Const(k) if k == 0 => error("zero stride", step); '{}
 
         case _ =>
@@ -158,8 +154,8 @@ def cforRangeMacro(r: Expr[Range], body: Expr[Int => Unit]) (given qctx: QuoteCo
 
     case '{ ($i: Int) to $j by $step } =>
       step match {
-        case Const(k) if k  > 0 => strideUpTo(i,j,k)
-        case Const(k) if k  < 0 => strideDownTo(i,j,-k)
+        case Const(k) if k  > 0 => strideUpTo(i,j,Expr(k))
+        case Const(k) if k  < 0 => strideDownTo(i,j,Expr(-k))
         case Const(k) if k == 0 => error("zero stride", step); '{}
 
         case _ =>

--- a/src/main/scala/spire/syntax/package.scala
+++ b/src/main/scala/spire/syntax/package.scala
@@ -1,13 +1,10 @@
 package spire.syntax
 
 object cfor extends CforSyntax
-
 object eq extends EqSyntax
 object partialOrder extends PartialOrderSyntax
 object order extends OrderSyntax
-
 object rig extends CRigSyntax
 object ring extends CRingSyntax
 object field extends FieldSyntax
-
 object all extends AllSyntax

--- a/src/main/scala/spire/syntax/primitives.scala
+++ b/src/main/scala/spire/syntax/primitives.scala
@@ -1,0 +1,17 @@
+package spire.syntax
+
+import spire.algebra.{Field, CRing}
+
+object primitives {
+
+  inline def (n: => Int) as [A](given A: CRing[A]): A = inline n match
+    case 0 => A.zero
+    case 1 => A.one
+    case n => A.fromInt(n)
+
+  inline def (n: => Double) as [A](given A: Field[A]): A = inline n match
+    case 0 => A.zero
+    case 1 => A.one
+    case n => A.fromDouble(n)
+
+}

--- a/src/test/scala/spire/GenericLiterals.scala
+++ b/src/test/scala/spire/GenericLiterals.scala
@@ -1,13 +1,25 @@
 package spire
 
-import spire.syntax.primitives.given
-import spire.math.Rat
+import spire.syntax.literals.given
+import spire.algebra.{Field, CRing}
 
 object GenericLiterals {
-  val planck: Rat   = 662607015e-35
-  val precise: Rat  = 6626070157483679999e-50
-  val one: Rat      = 1
-  val zero: Rat     = 0.0
-  val big: Rat      = 37237283824892382
-  val n: Rat        = 66260701574374783247326472374237846732747999999e35
+
+  // Field
+
+  def zeroF[A: Field]: A = 0.0                // summon[Field[A]].zero
+  def oneF[A: Field]: A  = 1                  // summon[Field[A]].one
+  def twoF[A: Field]: A  = 2                  // summon[Field[A]].fromInt(2)
+  def three[A: Field]: A = 3.0                // summon[Field[A]].fromDouble(3.0)
+  def bigF[A: Field]: A  = 37237283824892382  // summon[Field[A]].fromBigInt(BigInt(Array[Byte](0,-124,75,28,-62,-56,121,-34)))
+  def huge[A: Field]: A  = 1e1000             // summon[Field[A]].fromBigDecimal(BigDecimal("1E+1000"))
+
+  // CRing
+
+  def zero[A: CRing]: A  = 0                  // summon[CRing[A]].zero
+  def one[A: CRing]: A   = 1                  // summon[CRing[A]].one
+  def two[A: CRing]: A   = 2                  // summon[CRing[A]].fromInt(2)
+  def hexI[A: CRing]: A  = 0xCAFE             // summon[CRing[A]].fromInt(51966)
+  def hexB[A: CRing]: A  = 0xCAFEBABE000000F  // summon[CRing[A]].fromBigInt(BigInt(Array[Byte](12,-81,-21,-85,-32,0,0,15)))
+  def big[A: CRing]: A   = 37237283824892382  // summon[CRing[A]].fromBigInt(BigInt(Array[Byte](0,-124,75,28,-62,-56,121,-34)))
 }


### PR DESCRIPTION
- replace all mentions of `implicit` with `given`
- remove `implicitConversions` language import
- Factored out generic literals givens into a new object `spire.syntax.literals`
- Rename `spire.implicits` to `spire.instances`
- `fromDouble` no longer converts to `Long`